### PR TITLE
Remove optionals files for production environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/doc                export-ignore
+/exemples           export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/condorcet-logo.psd export-ignore
+/condorcet-logo.jpg export-ignore


### PR DESCRIPTION
When using `composer install --prefer-dist`, typically in a production environment, these files will not be downloaded.