### PR TITLE
Composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ lib/Condorcet/algorithms/KemenyYoung-Data/10.data
 .idea/
 
 *.sqlite
+
+# composer
+/vendor/
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,6 @@
         "ext-pdo": "Allow to use database for very large elections.",
         "ext-pdo_sqlite": "Use sqlite3 bases for very large elections."
     },
-     "repositories": [
-         {
-         "type": "vcs",
-         "url": "https://github.com/julien-boudry/Condorcet"
-         }
-     ],
     "autoload": {
         "psr-4": { "Condorcet\\": "lib/" }
     }


### PR DESCRIPTION
* add composer artifacts to `.gitignore`
* remove useless `repositories` section from `composer.json`

I did not remove `.idea/` from your `composer.json`, but a *good practice* is to exclude IDE/editor specific files in a global ignore file. See https://help.github.com/articles/ignoring-files/#create-a-global-gitignore for information on how to create such a file. This prevents an ever growing list of IDE, editor and operating system specific files from your `.gitignore` file.