### PR TITLE
Added first unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+php:
+  - '7.1'
+  - nightly
+
+matrix:
+    allow_failures:
+        - php: nightly
+
+script:
+    - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,27 @@
         "ext-ctype": "*",
         "ext-json": "*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^6.2"
+    },
     "suggest": {
         "ext-pdo": "Allow to use database for very large elections.",
         "ext-pdo_sqlite": "Use sqlite3 bases for very large elections."
     },
     "autoload": {
         "psr-4": { "Condorcet\\": "lib/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Condorcet\\": "test/" }
+    },
+    "archive": {
+        "exclude": [
+            "/test",
+            "/doc",
+            "/examples",
+            "condorcet-logo.psd",
+            "phpcs.xml.dist",
+            ".travis.yml"
+        ]
     }
 }

--- a/lib/DataManager/VotesManager.php
+++ b/lib/DataManager/VotesManager.php
@@ -47,7 +47,7 @@ class VotesManager extends ArrayManager
             }
         };
 
-        $context->election = $this->_link[0];
+        $context->election = $this->_link[0] ?? null;
 
         return $context;
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true" bootstrap="vendor/autoload.php" forceCoversAnnotation = "true">
+    <testsuites>
+        <testsuite name="PHPUnit tests">
+            <directory>./test</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./lib</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/test/DataManager/VotesManagerTest.php
+++ b/test/DataManager/VotesManagerTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Condorcet\DataManager;
+
+use Condorcet\CondorcetException;
+use Condorcet\Election;
+use Condorcet\Vote;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Condorcet\DataManager\VotesManager
+ * @covers \Condorcet\DataManager\ArrayManager
+ */
+class VotesManagerTest extends TestCase
+{
+    private $election;
+
+    /**
+     * @var VotesManager
+     */
+    private $empty_votes_manager;
+
+    /**
+     * @var VotesManager
+     */
+    private $votes_manager;
+
+    protected function setUp()
+    {
+        $this->election = new Election();
+
+        $this->votes_manager = new VotesManager($this->election);
+        $this->empty_votes_manager = new VotesManager();
+    }
+
+    public function testGetDataContextObject()
+    {
+        // Testing the class type is not possible, since it is an
+        // anonymous class not implementing any interface.
+        self::assertNull($this->empty_votes_manager->getDataContextObject()->election);
+        self::assertSame($this->election, $this->votes_manager->getDataContextObject()->election);
+    }
+
+    public function testOffsetSet()
+    {
+        $vote = new Vote([]);
+
+        // add valid vote
+        $this->empty_votes_manager[] = $vote;
+        self::assertSame($vote, $this->empty_votes_manager->getVotesList()[0]);
+
+        // add invalid vote
+        self::expectException(CondorcetException::class);
+        $this->empty_votes_manager[] = null;
+    }
+
+    public function testOffsetUnset()
+    {
+        $before_list = $this->empty_votes_manager->getVotesList();
+
+        // unset non existent vote
+        unset($this->empty_votes_manager[0]);
+        self::assertSame($before_list, $this->empty_votes_manager->getVotesList());
+
+        // unset existing vote
+        $this->empty_votes_manager[] = new Vote([]);
+        unset($this->empty_votes_manager[0]);
+        self::assertEmpty($this->empty_votes_manager->getVotesList());
+    }
+
+    public function testGetVoteKey()
+    {
+        self::assertFalse($this->empty_votes_manager->getVoteKey(new Vote([])));
+    }
+
+    public function testGetVotesList()
+    {
+        // Without Election
+        self::assertEmpty($this->empty_votes_manager->getVotesList());
+
+        $this->empty_votes_manager[] = new Vote([]);
+        self::assertNotEmpty($this->empty_votes_manager->getVotesList());
+
+        // With Election
+        self::assertEmpty($this->votes_manager->getVotesList());
+
+        $this->election->addCandidate('candidate');
+        $this->election->addVote(new Vote(['candidate']));
+
+        $this->votes_manager[] = new Vote([]);
+        self::assertNotEmpty($this->votes_manager->getVotesList());
+    }
+}


### PR DESCRIPTION
* Added PHPUnit (run with `vendor/bin/phpunit`)
* Added `.travis.yml` (activate CI for your project on travis-ci.org)
* Added `archive exclude` section to `composer.json`

You can run with coverage using `vendor/bin/phpunit
--html-coverage=/tmp/coverage` and then viewing
`/tmp/coverage/index.html`

Documentation about the `archive` section of composer can be found at:
https://getcomposer.org/doc/04-schema.md#archive

Example run of PHPUnit:
```
$ vendor/bin/phpunit

PHPUnit 6.2.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7-1+ubuntu14.04.1+deb.sury.org+1
Configuration: /home/hboomsma/projects/Condorcet/phpunit.xml.dist

.....                                                5 / 5 (100%)

Time: 27 ms, Memory: 4.00MB

OK (5 tests, 11 assertions)
```