### PR TITLE
Fix typos

### DIFF
--- a/Documentation/Election Class/public static Election--setMaxParseIteration.md
+++ b/Documentation/Election Class/public static Election--setMaxParseIteration.md
@@ -10,7 +10,7 @@ Maximum input for each use of Election::parseCandidate && Election::parseVote. W
     
 
 ##### **maxParseIterations:** *?int*   
-Null will desactivate this functionnality. Else, enter an integer.    
+Null will deactivate this functionality. Else, enter an integer.    
 
 
 ### Return value:   

--- a/Documentation/Election Class/public static Election--setMaxVoteNumber.md
+++ b/Documentation/Election Class/public static Election--setMaxVoteNumber.md
@@ -10,7 +10,7 @@ Add a limitation on Election::addVote and related methods. You can't add new vot
     
 
 ##### **maxVotesNumber:** *?int*   
-Null will desactivate this functionnality. An integer will fix the limit.    
+Null will deactivate this functionality. An integer will fix the limit.    
 
 
 ### Return value:   

--- a/Documentation/doc.yaml
+++ b/Documentation/doc.yaml
@@ -82,7 +82,7 @@
   name: addCandidate
   input:
     candidate:
-      text: Alphanumeric string or CondorcetPHP\Condorcet\Candidate objet. Your candidate name will be trim(). If null, will create for you a new candidate with an automatic name.
+      text: Alphanumeric string or CondorcetPHP\Condorcet\Candidate object. Your candidate name will be trim(). If null, will create for you a new candidate with an automatic name.
 
 
 -
@@ -253,14 +253,14 @@
   name: setMaxParseIteration
   input:
     maxParseIterations:
-      text: 'Null will desactivate this functionnality. Else, enter an integer.'
+      text: 'Null will deactivate this functionality. Else, enter an integer.'
 
 -
   class: Election
   name: setMaxVoteNumber
   input:
     maxVotesNumber:
-      text: Null will desactivate this functionnality. An integer will fix the limit.
+      text: Null will deactivate this functionality. An integer will fix the limit.
 
 
 -

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Condorcet Natural Winner & Loser
 ```
 
 ```shell
-condorcet election --candidates="A;B;C" --votes="A>B>C ; B>A ; A" -lr -i --desactivate-implicit-ranking
+condorcet election --candidates="A;B;C" --votes="A>B>C ; B>A ; A" -lr -i --deactivate-implicit-ranking
 +-----------+- Registered Vote List --+-----------+
 | Vote Num. | Vote      | Vote Weight | Vote Tags |
 +-----------+-----------+-------------+-----------+

--- a/Tests/lib/Console/Commands/ElectionCommandTest.php
+++ b/Tests/lib/Console/Commands/ElectionCommandTest.php
@@ -32,7 +32,7 @@ class ElectionCommandTest extends TestCase
                                             '--allows-votes-weight' => null,
                                             '--no-tie' => null,
                                             '--list-votes' => null,
-                                            '--desactivate-implicit-ranking' => null,
+                                            '--deactivate-implicit-ranking' => null,
                                             '--show-pairwise' => null
                                         ],[
                                             'verbosity' => OutputInterface::VERBOSITY_VERBOSE
@@ -42,14 +42,14 @@ class ElectionCommandTest extends TestCase
         $output = $this->electionCommand->getDisplay();
         // \var_dump($output);
 
-        self::assertStringContainsString('3 Candidates(s) Registered  ||  3 Vote(s) Registered', $output);
+        self::assertStringContainsString('3 candidates(s) registered  ||  3 vote(s) registered', $output);
 
         self::assertStringContainsString('Schulze', $output);
-        self::assertStringContainsString('Registered Candidates', $output);
-        self::assertStringContainsString('Stats - Votes Registration', $output);
+        self::assertStringContainsString('Registered candidates', $output);
+        self::assertStringContainsString('Stats - votes registration', $output);
+        self::assertStringContainsString('Registered votes list', $output);
         self::assertStringContainsString('Pairwise', $output);
         self::assertStringContainsString('Stats:', $output);
-        self::assertStringContainsString('Votes List', $output);
 
         self::assertMatchesRegularExpression('/Is vote weight allowed\?( )+TRUE/', $output);
         self::assertMatchesRegularExpression('/Votes are evaluated according to the implicit ranking rule\?( )+FALSE./', $output);

--- a/lib/Console/Commands/ElectionCommand.php
+++ b/lib/Console/Commands/ElectionCommand.php
@@ -63,7 +63,11 @@ class ElectionCommand extends Command
             )
             ->addOption(      'stats', 's'
                             , InputOption::VALUE_NONE
-                            , 'Get detailled stats'
+                            , 'Get detailled stats (equivalent to --show-pairwise and --show-method-stats)'
+            )
+            ->addOption(      'show-method-stats', null
+                            , InputOption::VALUE_NONE
+                            , 'Get detailled stats per method'
             )
             ->addOption(      'show-pairwise', 'p'
                             , InputOption::VALUE_NONE
@@ -285,7 +289,7 @@ class ElectionCommand extends Command
             ;
 
             // Stats
-            if ($input->getOption('stats')) :
+            if ($input->getOption('show-method-stats') || $input->getOption('stats')) :
                 (new Table($output))
                     ->setHeaderTitle('Stats: '.$oneMethod)
                     ->setHeaders(['Stats'])

--- a/lib/Console/Commands/ElectionCommand.php
+++ b/lib/Console/Commands/ElectionCommand.php
@@ -51,23 +51,23 @@ class ElectionCommand extends Command
             ->setAliases(['condorcet'])
 
             ->setDescription('Process an election')
-            ->setHelp('This command takle candidates and votes in input. An output the résult of an election.')
+            ->setHelp('This command takes candidates and votes as input. The output is the result of that election.')
 
             ->addOption(      'candidates', 'c'
                             , InputOption::VALUE_REQUIRED
-                            , 'Candidates List file path or direct input'
+                            , 'Candidates list file path or direct input'
             )
             ->addOption(      'votes', 'w'
                             , InputOption::VALUE_REQUIRED
-                            , 'Votes List file path or direct input'
+                            , 'Votes list file path or direct input'
             )
             ->addOption(      'stats', 's'
                             , InputOption::VALUE_NONE
-                            , 'Get detailled stats (equivalent to --show-pairwise and --show-method-stats)'
+                            , 'Get detailed stats (equivalent to --show-pairwise and --show-method-stats)'
             )
             ->addOption(      'show-method-stats', null
                             , InputOption::VALUE_NONE
-                            , 'Get detailled stats per method'
+                            , 'Get detailed stats per method'
             )
             ->addOption(      'show-pairwise', 'p'
                             , InputOption::VALUE_NONE
@@ -75,15 +75,15 @@ class ElectionCommand extends Command
             )
             ->addOption(      'list-votes', 'l'
                             , InputOption::VALUE_NONE
-                            , 'List Registered Votes'
+                            , 'List registered votes'
             )
             ->addOption(      'natural-condorcet', 'r'
                             , InputOption::VALUE_NONE
-                            , 'Print natural Condorcet Winner / Loser'
+                            , 'Print natural Condorcet winner / loser'
             )
-            ->addOption(      'desactivate-implicit-ranking', 'i'
+            ->addOption(      'deactivate-implicit-ranking', 'i'
                             , InputOption::VALUE_NONE
-                            , 'Desactivate Implicit Ranking'
+                            , 'Deactivate implicit ranking'
             )
             ->addOption(      'allows-votes-weight', 'g'
                             , InputOption::VALUE_NONE
@@ -94,19 +94,19 @@ class ElectionCommand extends Command
                             , 'Add no-tie constraint for vote'
             )
 
-            ->addOption(      'desactivate-file-cache', null
+            ->addOption(      'deactivate-file-cache', null
                             , InputOption::VALUE_NONE
                             , "Don't use a disk cache for very large elections. Forces to work exclusively in RAM."
             )
             ->addOption(      'votes-per-mb', null
                             , InputOption::VALUE_REQUIRED
-                            , "Adjust memory in cas eof failure. default is 100. Try to lower it."
+                            , "Adjust memory in case of failure. Default is 100. Try to lower it."
             )
 
             ->addArgument(
                              'methods'
                             , InputArgument::OPTIONAL | InputArgument::IS_ARRAY
-                            , 'Methods to ouput'
+                            , 'Methods to output'
             )
         ;
     }
@@ -125,7 +125,7 @@ class ElectionCommand extends Command
         $this->election = new Election;
 
             /// Implicit Ranking
-            if ($input->getOption('desactivate-implicit-ranking')) :
+            if ($input->getOption('deactivate-implicit-ranking')) :
                 $this->election->setImplicitRanking(false);
             endif;
 
@@ -156,7 +156,7 @@ class ElectionCommand extends Command
             $registeringCandidates = [];
 
             while (true) :
-                $question = new Question('Please registering candidate N°'.++$c.' or press enter: ', null);
+                $question = new Question('Please register candidate N°'.++$c.' or press enter: ', null);
                 $answer = $helper->ask($input, $output, $question);
 
                 if ($answer === null) :
@@ -177,7 +177,7 @@ class ElectionCommand extends Command
             $registeringvotes = [];
 
             while (true) :
-                $question = new Question('Please registering vote N°'.++$c.' or press enter: ', null);
+                $question = new Question('Please register vote N°'.++$c.' or press enter: ', null);
                 $answer = $helper->ask($input, $output, $question);
 
                 if ($answer === null) :
@@ -214,12 +214,12 @@ class ElectionCommand extends Command
 
         unset($callBack);
 
-        // Sum Upphp -v
-        $io->section('Sum Up');
+        // Summary
+        $io->section('Summary');
 
-        $output->write($this->election->countCandidates().' Candidates(s) Registered');
+        $output->write($this->election->countCandidates().' candidates(s) registered');
         $output->write('  ||  ');
-        $output->writeln($this->election->countVotes().' Vote(s) Registered');
+        $output->writeln($this->election->countVotes().' vote(s) registered');
         $output->writeln('<info>==========================</>');
 
         $io->definitionList(
@@ -250,14 +250,14 @@ class ElectionCommand extends Command
 
         // Natural Condorcet
         if ($input->getOption('natural-condorcet')) :
-            $io->section('Condorcet Natural Winner & Loser');
+            $io->section('Condorcet natural winner & loser');
 
             (new Table($output))
                 ->setHeaderTitle('Natural Condorcet')
                 ->setHeaders(['Type', 'Candidate'])
                 ->setRows([
-                            ['* Condorcet Winner', ( $this->election->getCondorcetWinner()->getName() ?? 'NULL' )],
-                            ['# Condorcet Loser', ( $this->election->getCondorcetLoser()->getName() ?? 'NULL' )]
+                            ['* Condorcet winner', ( $this->election->getCondorcetWinner()->getName() ?? 'NULL' )],
+                            ['# Condorcet loser', ( $this->election->getCondorcetLoser()->getName() ?? 'NULL' )]
                 ])
 
                 ->render()
@@ -271,7 +271,7 @@ class ElectionCommand extends Command
 
         $methods = $this->prepareMethods($input->getArgument('methods'));
 
-        $io->section('Results per Methods');
+        $io->section('Results per methods');
 
         foreach ($methods as $oneMethod) :
 
@@ -320,7 +320,7 @@ class ElectionCommand extends Command
 
     protected function sectionVerbose (SymfonyStyle $io, InputInterface $input, OutputInterface $output) : void
     {
-        $io->section('Detailled election input');
+        $io->section('Detailed election input');
 
         $this->displayCandidatesList($output);
         $this->displayVotesCount($output);
@@ -333,8 +333,8 @@ class ElectionCommand extends Command
         if (!$this->candidatesListIsWrite) :
             // Candidate List
             ($candidateTable = new Table($output))
-                ->setHeaderTitle('Registered Candidates')
-                ->setHeaders(['Num', 'Candidate Name'])
+                ->setHeaderTitle('Registered candidates')
+                ->setHeaders(['Num', 'Candidate name'])
                 ->setStyle($this->centerPadTypeStyle)
                 ->setColumnWidth(0, 14)
             ;
@@ -355,16 +355,16 @@ class ElectionCommand extends Command
         if (!$this->votesCountIsWrite) :
             // Votes Count
             ($votesStatsTable = new Table($output))
-                ->setHeaderTitle('Stats - Votes Registration')
+                ->setHeaderTitle('Stats - votes registration')
                 ->setHeaders(['Stats', 'Value'])
                 ->setColumnStyle(0,(new Tablestyle())->setPadType(\STR_PAD_LEFT))
             ;
 
-            $votesStatsTable->addRow(['Count Registered Votes', $this->election->countValidVoteWithConstraints()]);
-            $votesStatsTable->addRow(['Count Valid Registered Votes with constraints', $this->election->countValidVoteWithConstraints()]);
-            $votesStatsTable->addRow(['Count Invalid Registered Votes with constraints', $this->election->countInvalidVoteWithConstraints()]);
-            $votesStatsTable->addRow(['Sum Vote Weight', $this->election->sumVotesWeight()]);
-            $votesStatsTable->addRow(['Sum Valid Votes Weight with constraints', $this->election->sumValidVotesWeightWithConstraints()]);
+            $votesStatsTable->addRow(['Count registered votes', $this->election->countValidVoteWithConstraints()]);
+            $votesStatsTable->addRow(['Count valid registered votes with constraints', $this->election->countValidVoteWithConstraints()]);
+            $votesStatsTable->addRow(['Count invalid registered votes with constraints', $this->election->countInvalidVoteWithConstraints()]);
+            $votesStatsTable->addRow(['Sum vote weight', $this->election->sumVotesWeight()]);
+            $votesStatsTable->addRow(['Sum valid votes weight with constraints', $this->election->sumValidVotesWeightWithConstraints()]);
 
             $votesStatsTable->render();
 
@@ -375,7 +375,7 @@ class ElectionCommand extends Command
     public function displayVotesList (OutputInterface $output) : void
     {
         ($votesTable = new Table($output))
-            ->setHeaderTitle('Registered Votes List')
+            ->setHeaderTitle('Registered votes list')
             ->setHeaders(['Vote Num.', 'Vote', 'Vote Weight', 'Vote Tags'])
         ;
 
@@ -391,7 +391,7 @@ class ElectionCommand extends Command
         if (!$this->pairwiseIsWrite) :
             (new Table($output))
                 ->setHeaderTitle('Pairwise')
-                ->setHeaders(['For each candidate, show his win, null or lose'])
+                ->setHeaders(['For each candidate, show their win, null or lose'])
                 ->setRows([[preg_replace('#!!float (\d+)#', '\1.0', Yaml::dump($this->election->getExplicitPairwise(),100))]])
 
                 ->render()
@@ -470,7 +470,7 @@ class ElectionCommand extends Command
 
     protected function useDataHandler (InputInterface $input) : ?\Closure
     {
-        if ( $input->getOption('desactivate-file-cache') || !\class_exists('\PDO') || !\in_array(needle: 'sqlite', haystack: \PDO::getAvailableDrivers(), strict: true) ) :
+        if ( $input->getOption('deactivate-file-cache') || !\class_exists('\PDO') || !\in_array(needle: 'sqlite', haystack: \PDO::getAvailableDrivers(), strict: true) ) :
             return null;
         else :
             $election = $this->election;


### PR DESCRIPTION
Hi,

please review this pull request, where I've fixed some typos. Mostly, they are about capitalizations. However, please note that I've also fixed two typos in the options for the command line program. I think I've been able to spot all occurrences of those, so that the command line program and the documentation are in sync, but you might need to take a close look.

Regards,
Tobias