### PR TITLE
Implement CPO STV module

### DIFF
--- a/.github/workflows/building_phar_executable.yml
+++ b/.github/workflows/building_phar_executable.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/codacy_coverage.yml
+++ b/.github/workflows/codacy_coverage.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/.github/workflows/execute_all_tests.yml
+++ b/.github/workflows/execute_all_tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2

--- a/Benchmarks/KemenyYoungBench.php
+++ b/Benchmarks/KemenyYoungBench.php
@@ -14,12 +14,12 @@ class KemenyYoungBench
 {
     public function __construct()
     {
-        KemenyYoung::$MaxCandidates = 9;
+        KemenyYoung::$MaxCandidates = 10;
     }
 
     public function provideCandidatesCount (): \Generator
     {
-        for ($i = 1 ; $i <= 9 ; $i++) :
+        for ($i = 1 ; $i <= 10 ; $i++) :
             yield $i => ['candidatesCount' => $i];
         endfor;
     }

--- a/Benchmarks/KemenyYoungBench.php
+++ b/Benchmarks/KemenyYoungBench.php
@@ -19,7 +19,7 @@ class KemenyYoungBench
 
     public function provideCandidatesCount (): \Generator
     {
-        for ($i = 2 ; $i <= 9 ; $i++) :
+        for ($i = 1 ; $i <= 9 ; $i++) :
             yield $i => ['candidatesCount' => $i];
         endfor;
     }

--- a/Tests/lib/Algo/Methods/KemenyYoung/KemenyYoungTest.php
+++ b/Tests/lib/Algo/Methods/KemenyYoung/KemenyYoungTest.php
@@ -170,4 +170,13 @@ class KemenyYoungTest extends TestCase
 
         self::assertSame(true,true);
     }
+
+    public function testKemenyWithOnly1Candidate ()
+    {
+        $candidate[] = $this->election->addCandidate();
+
+        $this->election->addVote($candidate);
+
+        self::assertSame($candidate[0],$this->election->getWinner('KemenyYoung'));
+    }
 }

--- a/Tests/lib/Algo/Methods/STV/CPO_StvTest.php
+++ b/Tests/lib/Algo/Methods/STV/CPO_StvTest.php
@@ -86,4 +86,20 @@ class CPO_StvTest extends TestCase
         self::assertSame($expectedRanking, $this->election->getResult('CPO STV')->getResultAsArray(true));
     }
 
+    // In this example, only Borda method will break A and B
+    public function testEquality1 (): void
+    {
+        // Ref
+        $this->election->setNumberOfSeats(2);
+
+        $this->election->parseCandidates('A;B;C');
+
+        $this->election->addVote('A>B>C');
+        $this->election->addVote('B>A>C');
+        $this->election->addVote('B>C>A');
+        $this->election->addVote('A>B>C');
+
+        self::assertSame('B > A', $this->election->getResult('CPO STV')->getResultAsString());
+    }
+
 }

--- a/Tests/lib/Algo/Methods/STV/CPO_StvTest.php
+++ b/Tests/lib/Algo/Methods/STV/CPO_StvTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace CondorcetPHP\Condorcet\Tests\Algo\STV;
+
+use CondorcetPHP\Condorcet\Election;
+use CondorcetPHP\Condorcet\Algo\Tools\StvQuotas;
+use PHPUnit\Framework\TestCase;
+
+class CPO_StvTest extends TestCase
+{
+    private readonly Election $election;
+
+    public function setUp(): void
+    {
+        $this->election = new Election;
+    }
+
+    public function tearDown(): void
+    {
+        $this->election->setMethodOption('STV', 'Quota', StvQuotas::DROOP);
+        $this->election->setMethodOption('CPO STV', 'Quota', StvQuotas::HAGENBACH_BISCHOFF);
+    }
+
+    public function testCPO1 (): void
+    {
+        # From https://en.wikipedia.org/wiki/CPO-STV
+
+        $this->election->addCandidate('Andrea'); // key 0
+        $this->election->addCandidate('Brad'); // key 1
+        $this->election->addCandidate('Carter'); // key 2
+        $this->election->addCandidate('Delilah'); // key 3
+        $this->election->addCandidate('Scott'); // key 4
+
+        $this->election->setImplicitRanking(false);
+        $this->election->allowsVoteWeight(true);
+
+        $this->election->parseVotes('
+            Andrea ^25
+            Carter > Brad > Delilah ^34
+            Brad > Delilah ^7
+            Delilah > Brad ^8
+            Delilah > Scott ^5
+            Scott > Delilah ^21
+        ');
+
+        $this->election->setNumberOfSeats(3);
+
+        self::assertSame( [
+                1 => 'Carter',
+                2 => 'Andrea',
+                3 => 'Delilah'
+             ],
+            $this->election->getResult('CPO STV')->getResultAsArray(true)
+        );
+
+        // var_dump($this->election->getResult('CPO STV')->getStats());
+    }
+
+}

--- a/Tests/lib/Algo/Methods/STV/CPO_StvTest.php
+++ b/Tests/lib/Algo/Methods/STV/CPO_StvTest.php
@@ -57,4 +57,33 @@ class CPO_StvTest extends TestCase
         // var_dump($this->election->getResult('CPO STV')->getStats());
     }
 
+    public function testLessOrEqualCandidatesThanSeats (): void
+    {
+        $expectedRanking = [
+            1 => 'Memphis',
+            2 => 'Nashville',
+            3 => 'Chattanooga',
+            4 => 'Knoxville',
+        ];
+
+        // Ref
+        $this->election->setNumberOfSeats(4);
+
+        $this->election->addCandidate('Memphis');
+        $this->election->addCandidate('Nashville');
+        $this->election->addCandidate('Knoxville');
+        $this->election->addCandidate('Chattanooga');
+
+        $this->election->parseVotes(' Memphis * 4
+                                    Nashville * 3
+                                    Chattanooga * 2
+                                    Knoxville * 1');
+
+        self::assertSame($expectedRanking, $this->election->getResult('CPO STV')->getResultAsArray(true));
+
+        $this->election->setNumberOfSeats(5);
+
+        self::assertSame($expectedRanking, $this->election->getResult('CPO STV')->getResultAsArray(true));
+    }
+
 }

--- a/Tests/lib/Console/Commands/ElectionCommandTest.php
+++ b/Tests/lib/Console/Commands/ElectionCommandTest.php
@@ -221,7 +221,7 @@ class ElectionCommandTest extends TestCase
         $this->electionCommand->execute([
                                             '--candidates' => 'A;B;C',
                                             '--votes-per-mb' => 1,
-                                            '--votes' => 'A>B>C * '.( ((int) \preg_replace('`[^0-9]`', '', \ini_get('memory_limit'))) + 1), # Must be superior to memory limit in MB
+                                            '--votes' => 'A>B>C * '.( ((int) \preg_replace('`[^0-9]`', '', ElectionCommand::$forceIniMemoryLimitTo)) + 1), # Must be superior to memory limit in MB
                                         ], [
                                             'verbosity' => OutputInterface::VERBOSITY_DEBUG
                                         ]);

--- a/Tests/lib/Console/Commands/ElectionCommandTest.php
+++ b/Tests/lib/Console/Commands/ElectionCommandTest.php
@@ -368,7 +368,7 @@ class ElectionCommandTest extends TestCase
         self::assertStringContainsString('Sum vote weight | 339', $output);
 
         self::assertStringContainsString('Jonathan Carter*', $output); # Condorcet Winner
-        self::assertStringContainsString('Seats:        | 1', $output);
+        self::assertStringContainsString('Seats:  | 1', $output);
 
         self::assertStringContainsString('[OK] Success', $output);
     }
@@ -398,7 +398,7 @@ class ElectionCommandTest extends TestCase
         self::assertStringContainsString('Sum vote weight | 380', $output);
 
         self::assertStringContainsString('Candidate  1*', $output); # Condorcet Winner
-        self::assertStringContainsString('Seats:        | 3', $output);
+        self::assertStringContainsString('Seats:  | 3', $output);
 
         self::assertStringContainsString('[OK] Success', $output);
     }

--- a/Tests/lib/Console/Commands/ElectionCommandTest.php
+++ b/Tests/lib/Console/Commands/ElectionCommandTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CondorcetPHP\Condorcet\Tests\Console\Commands;
 
+use CondorcetPHP\Condorcet\Console\Commands\ElectionCommand;
 use CondorcetPHP\Condorcet\Throwable\ResultRequestedWithoutVotesException;
 use PHPUnit\Framework\TestCase;
 use CondorcetPHP\Condorcet\Console\CondorcetApplication;
@@ -215,6 +216,8 @@ class ElectionCommandTest extends TestCase
 
     public function testVoteWithDb1 (): void
     {
+        ElectionCommand::$forceIniMemoryLimitTo = '128M';
+
         $this->electionCommand->execute([
                                             '--candidates' => 'A;B;C',
                                             '--votes-per-mb' => 1,
@@ -227,6 +230,8 @@ class ElectionCommandTest extends TestCase
 
         self::assertStringContainsString('[INFO] Votes per Mb: 1', $output);
         self::assertStringContainsString('[INFO] Db is used: yes, using path:', $output);
+
+        ElectionCommand::$forceIniMemoryLimitTo = null;
 
         # And absence of this error: unlink(path): Resource temporarily unavailable
     }
@@ -319,6 +324,8 @@ class ElectionCommandTest extends TestCase
 
     public function testVoteWithDb_CondorcetElectionFormat (): void
     {
+        ElectionCommand::$forceIniMemoryLimitTo = '128M';
+
         $this->electionCommand->execute([
                                             '--votes-per-mb' => 1,
                                             '--import-condorcet-election-format' => __DIR__.'/../../Tools/Converters/CondorcetElectionFormatData/test3.cvotes',
@@ -330,6 +337,8 @@ class ElectionCommandTest extends TestCase
 
         self::assertStringContainsString('[INFO] Votes per Mb: 1', $output);
         self::assertStringContainsString('[INFO] Db is used: yes, using path:', $output);
+
+        ElectionCommand::$forceIniMemoryLimitTo = null;
 
         # And absence of this error: unlink(path): Resource temporarily unavailable
     }

--- a/lib/Algo/Method.php
+++ b/lib/Algo/Method.php
@@ -31,7 +31,7 @@ abstract class Method
 
     // Static
 
-    final public static function setOption (string $optionName, \BackedEnum|int $optionValue): bool
+    final public static function setOption (string $optionName, \BackedEnum|int|string $optionValue): bool
     {
         $optionVar = 'option'.ucfirst($optionName);
 

--- a/lib/Algo/Methods/Borda/BordaCount.php
+++ b/lib/Algo/Methods/Borda/BordaCount.php
@@ -57,7 +57,7 @@ class BordaCount extends Method implements MethodInterface
 
             for ($i = 0 ; $i < $weight ; $i++) :
                 $CandidatesRanked = 0;
-                $oneRanking = $oneVote->getContextualRanking($election);
+                $oneRanking = $oneVote->getContextualRanking($election, false);
 
                 foreach ($oneRanking as $oneRank) :
                     $rankScore = 0.0;

--- a/lib/Algo/Methods/InstantRunoff/InstantRunoff.php
+++ b/lib/Algo/Methods/InstantRunoff/InstantRunoff.php
@@ -120,7 +120,7 @@ class InstantRunoff extends Method implements MethodInterface
 
             $weight = $oneVote->getWeight($election);
 
-            foreach ($oneVote->getContextualRanking($election) as $oneRank) :
+            foreach ($oneVote->getContextualRanking($election, false) as $oneRank) :
                 foreach ($oneRank as $oneCandidate) :
                     if (\count($oneRank) !== 1) :
                         break;

--- a/lib/Algo/Methods/KemenyYoung/KemenyYoung.php
+++ b/lib/Algo/Methods/KemenyYoung/KemenyYoung.php
@@ -28,7 +28,7 @@ class KemenyYoung extends Method implements MethodInterface
     final public const CONFLICT_WARNING_CODE = 42;
 
     // Limits
-        /* If you need to put it on 9, You must use \ini_set('memory_limit','1024M'); before. The first use will be slower because Kemeny-Young will work without pre-calculated data of Permutationss.
+        /* If you need to put it on 9, You must use \ini_set('memory_limit','1024M'); before. The first use will be slower because Kemeny-Young will work without pre-calculated data of Permutations.
         Do not try to go to 10, it is not viable! */
         public static ?int $MaxCandidates = 8;
 

--- a/lib/Algo/Methods/KemenyYoung/KemenyYoung.php
+++ b/lib/Algo/Methods/KemenyYoung/KemenyYoung.php
@@ -136,7 +136,7 @@ class KemenyYoung extends Method implements MethodInterface
         while (!$f->eof()) :
             $l = trim($f->fgets());
 
-            if (empty($l)) : continue; endif;
+            if (\strlen($l) < 1) : continue; endif;
 
             $oneResult = explode(',', $l);
 

--- a/lib/Algo/Methods/KemenyYoung/KemenyYoung.php
+++ b/lib/Algo/Methods/KemenyYoung/KemenyYoung.php
@@ -16,7 +16,7 @@ use CondorcetPHP\Condorcet\Dev\CondorcetDocumentationGenerator\CondorcetDocAttri
 use CondorcetPHP\Condorcet\Result;
 use CondorcetPHP\Condorcet\Algo\{Method, MethodInterface};
 use CondorcetPHP\Condorcet\Algo\Tools\Permutations;
-use SplFileObject;
+use SplFixedArray;
 
 // Kemeny-Young is a Condorcet Algorithm | http://en.wikipedia.org/wiki/Kemeny%E2%80%93Young_method
 class KemenyYoung extends Method implements MethodInterface
@@ -36,7 +36,7 @@ class KemenyYoung extends Method implements MethodInterface
     public static bool $devWriteCache = false;
 
     // Kemeny Young
-    protected array $_PossibleRanking = [];
+    protected SplFixedArray $_PossibleRanking;
     protected array $_RankingScore = [];
 
 
@@ -110,7 +110,8 @@ class KemenyYoung extends Method implements MethodInterface
     protected function calcPossibleRanking (): void
     {
         $election = $this->getElection();
-        
+        $this->_PossibleRanking = new SplFixedArray(Permutations::countPossiblePermutations($election->countCandidates()));
+
         $i = 0;
         $search = [];
         $replace = [];
@@ -131,6 +132,7 @@ class KemenyYoung extends Method implements MethodInterface
         // Read Cache & Compute
         $f = new \SplFileObject($path, 'r');
 
+        $arrKey = 0;
         while (!$f->eof()) :
             $l = trim($f->fgets());
 
@@ -148,7 +150,7 @@ class KemenyYoung extends Method implements MethodInterface
                 $resultToRegister[$rank++] = (int) $oneCandidate;
             endforeach;
 
-            $this->_PossibleRanking[] = $resultToRegister;
+            $this->_PossibleRanking[$arrKey++] = $resultToRegister;
         endwhile;
     }
 

--- a/lib/Algo/Methods/Majority/Majority_Core.php
+++ b/lib/Algo/Methods/Majority/Majority_Core.php
@@ -126,7 +126,7 @@ abstract class Majority_Core extends Method implements MethodInterface
 
             $weight = $oneVote->getWeight($election);
 
-            $oneRanking = $oneVote->getContextualRanking($election);
+            $oneRanking = $oneVote->getContextualRanking($election, false);
 
             if ( !empty($this->_admittedCandidates) ) :
                 foreach ($oneRanking as $rankKey => $oneRank) :

--- a/lib/Algo/Methods/STV/CPO_STV.php
+++ b/lib/Algo/Methods/STV/CPO_STV.php
@@ -49,7 +49,6 @@ class CPO_STV extends SingleTransferableVote
     {
         $rank = 0;
 
-        $candidatesList = \array_keys($this->getElection()->getCandidatesList());
         $this->votesNeededToWin = \round(self::$optionQuota->getQuota($this->getElection()->sumValidVotesWeightWithConstraints(), $this->getElection()->getNumberOfSeats()), self::DECIMAL_PRECISION, \PHP_ROUND_HALF_DOWN);
 
         // Compute Initial Score
@@ -63,70 +62,108 @@ class CPO_STV extends SingleTransferableVote
         endforeach;
 
         $numberOfCandidatesNeededToComplete = $this->getElection()->getNumberOfSeats() - \count($this->candidatesElectedFromFirstRound);
-        $this->candidatesEliminatedFromFirstRound = \array_diff($candidatesList, $this->candidatesElectedFromFirstRound);
+        $this->candidatesEliminatedFromFirstRound = \array_diff(\array_keys($this->getElection()->getCandidatesList()), $this->candidatesElectedFromFirstRound);
 
         if ($numberOfCandidatesNeededToComplete < \count($this->candidatesEliminatedFromFirstRound)) :
             // Compute all possible Ranking
             $this->outcomes = Combinations::compute($this->candidatesEliminatedFromFirstRound, $numberOfCandidatesNeededToComplete, $this->candidatesElectedFromFirstRound);
 
-            foreach ($this->outcomes as $MainOutcomeKey => $MainOutcomeR) :
-                foreach ($this->outcomes as $ComparedOutcomeKey => $ComparedOutcomeR) :
-                    $outcomeComparisonKey = $this->getOutcomesComparisonKey($MainOutcomeKey, $ComparedOutcomeKey);
+            // Compare it
+            $this->compareOutcomes();
 
-                    if ( $MainOutcomeKey === $ComparedOutcomeKey || \array_key_exists($outcomeComparisonKey, $this->outcomeComparisonTable) ) :
-                        continue;
+            // Select the best with a Condorcet method
+            $this->selectBestOutcome();
+            $result = $this->outcomes[$this->condorcetWinnerOutcome];
+
+        else :
+            $result = \array_keys($this->initialScoreTable);
+        endif;
+
+        // Sort the best Outcome candidate list using originals scores
+        \usort($result, fn (float $a, float $b): int => $this->initialScoreTable[$b] <=> $this->initialScoreTable[$a]);
+
+        // Results: Format Ranks from 1
+        $rank = 1;
+        $r = [];
+        foreach ($result as $candidateKey) :
+            $r[$rank++] = $candidateKey;
+        endforeach;
+
+        // Register result
+        $this->_Result = $this->createResult($r);
+    }
+
+    protected function compareOutcomes (): void
+    {
+        foreach ($this->outcomes as $MainOutcomeKey => $MainOutcomeR) :
+            foreach ($this->outcomes as $ComparedOutcomeKey => $ComparedOutcomeR) :
+                $outcomeComparisonKey = $this->getOutcomesComparisonKey($MainOutcomeKey, $ComparedOutcomeKey);
+
+                if ( $MainOutcomeKey === $ComparedOutcomeKey || \array_key_exists($outcomeComparisonKey, $this->outcomeComparisonTable) ) :
+                    continue;
+                endif;
+
+                $this->outcomeComparisonTable[$outcomeComparisonKey] = [];
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'] = [];
+
+                // Eliminate Candidates from Outcome
+                foreach (\array_keys($this->getElection()->getCandidatesList()) as $candidateKey) :
+                    if (!\in_array($candidateKey, $MainOutcomeR, true) && !\in_array($candidateKey, $ComparedOutcomeR, true)) :
+                        $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'][] = $candidateKey;
+                    endif;
+                endforeach;
+
+                // Make score again
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_exclusion'] = $this->makeScore([], [], $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded']);
+
+                $surplusToTransfer = [];
+                $winnerToJoin = [];
+                foreach($this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_exclusion'] as $candidateKey => $oneScore) :
+                    $surplus = $oneScore - $this->votesNeededToWin;
+
+                    if ($surplus >= 0 && \in_array($candidateKey, $MainOutcomeR, true) && \in_array($candidateKey,$ComparedOutcomeR, true)) :
+                        $surplusToTransfer[$candidateKey] ?? $surplusToTransfer[$candidateKey] = ['surplus' => 0, 'total' => 0];
+                        $surplusToTransfer[$candidateKey]['surplus'] += $surplus;
+                        $surplusToTransfer[$candidateKey]['total'] += $oneScore;
+                        $winnerToJoin[$candidateKey] = $this->votesNeededToWin;
+                    endif;
+                endforeach;
+
+                $winnerFromFirstRound = \array_keys($winnerToJoin);
+
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_surplus'] = $winnerToJoin + $this->makeScore($surplusToTransfer, $winnerFromFirstRound, $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'], 2);
+
+                // Outcome Score
+                $MainOutcomeScore = 0;
+                $ComparedOutcomeScore = 0;
+
+                foreach ($this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_surplus'] as $candidateKey => $candidateScore) :
+                    if (in_array($candidateKey, $MainOutcomeR, true)) :
+                        $MainOutcomeScore += $candidateScore;
                     endif;
 
-                    $this->outcomeComparisonTable[$outcomeComparisonKey] = [];
-                    $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'] = [];
-
-                    // Eliminate Candidates from Outcome
-                    foreach ($candidatesList as $candidateKey) :
-                        if (!\in_array($candidateKey, $MainOutcomeR, true) && !\in_array($candidateKey, $ComparedOutcomeR, true)) :
-                            $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'][] = $candidateKey;
-                        endif;
-                    endforeach;
-
-                    // Make score again
-                    $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_exclusion'] = $this->makeScore([], [], $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded']);
-
-                    $surplusToTransfer = [];
-                    $winnerToJoin = [];
-                    foreach($this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_exclusion'] as $candidateKey => $oneScore) :
-                        $surplus = $oneScore - $this->votesNeededToWin;
-
-                        if ($surplus >= 0 && \in_array($candidateKey, $MainOutcomeR, true) && \in_array($candidateKey,$ComparedOutcomeR, true)) :
-                            $surplusToTransfer[$candidateKey] ?? $surplusToTransfer[$candidateKey] = ['surplus' => 0, 'total' => 0];
-                            $surplusToTransfer[$candidateKey]['surplus'] += $surplus;
-                            $surplusToTransfer[$candidateKey]['total'] += $oneScore;
-                            $winnerToJoin[$candidateKey] = $this->votesNeededToWin;
-                        endif;
-                    endforeach;
-
-                    $winnerFromFirstRound = \array_keys($winnerToJoin);
-
-                    $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_surplus'] = $winnerToJoin + $this->makeScore($surplusToTransfer, $winnerFromFirstRound, $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'], 2);
-
-                    // Outcome Score
-                    $MainOutcomeScore = 0;
-                    $ComparedOutcomeScore = 0;
-
-                    foreach ($this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_surplus'] as $candidateKey => $candidateScore) :
-                        if (in_array($candidateKey, $MainOutcomeR, true)) :
-                            $MainOutcomeScore += $candidateScore;
-                        endif;
-
-                        if (in_array($candidateKey, $ComparedOutcomeR, true)) :
-                            $ComparedOutcomeScore += $candidateScore;
-                        endif;
-                    endforeach;
-
-                    $this->outcomeComparisonTable[$outcomeComparisonKey]['outcomes_scores'] = [$MainOutcomeKey => $MainOutcomeScore, $ComparedOutcomeKey => $ComparedOutcomeScore];
-
+                    if (in_array($candidateKey, $ComparedOutcomeR, true)) :
+                        $ComparedOutcomeScore += $candidateScore;
+                    endif;
                 endforeach;
-            endforeach;
 
-            // Chose Outcome with Condorcet
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['outcomes_scores'] = [$MainOutcomeKey => $MainOutcomeScore, $ComparedOutcomeKey => $ComparedOutcomeScore];
+
+            endforeach;
+        endforeach;
+    }
+
+    protected function getOutcomesComparisonKey (int $MainOutcomeKey, int $ComparedOutcomeKey): string
+    {
+        $minOutcome = (string) \min($MainOutcomeKey, $ComparedOutcomeKey);
+        $maxOutcome = (string) \max($MainOutcomeKey, $ComparedOutcomeKey);
+
+        return 'Outcome N° '.$minOutcome.' compared to Outcome N° '.$maxOutcome;
+    }
+
+    protected function selectBestOutcome (): void
+    {
+            // With Condorcet
             $winnerOutcomeElection = new Election;
             $winnerOutcomeElection->setImplicitRanking(false);
             $winnerOutcomeElection->allowsVoteWeight(true);
@@ -153,38 +190,10 @@ class CPO_STV extends SingleTransferableVote
                     $winnerOutcomeElection->addVote($vote2);
                 endforeach;
 
-            // Chose Outcome
             $completionMethodResult = $winnerOutcomeElection->getResult(self::$optionCondorcetCompletionMethod);
             $this->completionMethodPairwise = $winnerOutcomeElection->getExplicitPairwise();
             $this->completionMethodStats = $completionMethodResult->getStats();
             $this->condorcetWinnerOutcome = (int) $completionMethodResult->getWinner(self::$optionCondorcetCompletionMethod)->getName();
-
-            $result = $this->outcomes[$this->condorcetWinnerOutcome];
-
-        else :
-            $result = \array_keys($this->initialScoreTable);
-        endif;
-
-        // Sort Outcome using originals scores
-        \usort($result, fn (float $a, float $b): int => $this->initialScoreTable[$b] <=> $this->initialScoreTable[$a]);
-
-        // Results: Format Ranks
-        $rank = 1;
-        $r = [];
-        foreach ($result as $candidateKey) :
-            $r[$rank++] = $candidateKey;
-        endforeach;
-
-        // Register result
-        $this->_Result = $this->createResult($r);
-    }
-
-    protected function getOutcomesComparisonKey (int $MainOutcomeKey, int $ComparedOutcomeKey): string
-    {
-        $minOutcome = (string) \min($MainOutcomeKey, $ComparedOutcomeKey);
-        $maxOutcome = (string) \max($MainOutcomeKey, $ComparedOutcomeKey);
-
-        return 'Outcome N° '.$minOutcome.' compared to Outcome N° '.$maxOutcome;
     }
 
     protected function getStats(): array

--- a/lib/Algo/Methods/STV/CPO_STV.php
+++ b/lib/Algo/Methods/STV/CPO_STV.php
@@ -19,6 +19,7 @@ use CondorcetPHP\Condorcet\Algo\Tools\Combinations;
 use CondorcetPHP\Condorcet\Algo\Tools\StvQuotas;
 use CondorcetPHP\Condorcet\Election;
 use CondorcetPHP\Condorcet\Vote;
+use SplFixedArray;
 use stdClass;
 
 // Single transferable vote | https://en.wikipedia.org/wiki/CPO-STV
@@ -32,7 +33,7 @@ class CPO_STV extends SingleTransferableVote
 
     protected ?array $_Stats = null;
 
-    protected array $outcomes = [];
+    protected SplFixedArray $outcomes;
     protected readonly array $initialScoreTable;
     protected array $candidatesElectedFromFirstRound = [];
     protected readonly array $candidatesEliminatedFromFirstRound;
@@ -44,13 +45,10 @@ class CPO_STV extends SingleTransferableVote
 
 /////////// COMPUTE ///////////
 
-    //:: Alternative Vote ALGORITHM. :://
-
     protected function compute (): void
     {
         Vote::$cacheKey = new stdClass; // Performances
-
-        $rank = 0;
+        $this->outcomes = new SplFixedArray(0);
 
         $this->votesNeededToWin = \round(self::$optionQuota->getQuota($this->getElection()->sumValidVotesWeightWithConstraints(), $this->getElection()->getNumberOfSeats()), self::DECIMAL_PRECISION, \PHP_ROUND_HALF_DOWN);
 

--- a/lib/Algo/Methods/STV/CPO_STV.php
+++ b/lib/Algo/Methods/STV/CPO_STV.php
@@ -39,18 +39,18 @@ class CPO_STV extends SingleTransferableVote
     public const METHOD_NAME = ['CPO STV', 'CPO_STV', 'CPO-STV', 'CPO', 'Comparison of Pairs of Outcomes by the Single Transferable Vote', 'Tideman STV'];
 
     public static StvQuotas $optionQuota = StvQuotas::HAGENBACH_BISCHOFF;
-    public static string $optionCondorcetCompletionMethod = SchulzeMargin::class;
+    public static string $optionCondorcetCompletionMethod = SchulzeMargin::METHOD_NAME[0];
     public static array $optionTieBreakerMethods = [
-        SchulzeMargin::class,
-        SchulzeWinning::class,
-        SchulzeRatio::class,
-        BordaCount::class,
-        Copeland::class,
-        InstantRunoff::class,
-        MinimaxMargin::class,
-        MinimaxWinning::class,
-        DodgsonTidemanApproximation::class,
-        FirstPastThePost::class,
+        SchulzeMargin::METHOD_NAME[0],
+        SchulzeWinning::METHOD_NAME[0],
+        SchulzeRatio::METHOD_NAME[0],
+        BordaCount::METHOD_NAME[0],
+        Copeland::METHOD_NAME[0],
+        InstantRunoff::METHOD_NAME[0],
+        MinimaxMargin::METHOD_NAME[0],
+        MinimaxWinning::METHOD_NAME[0],
+        DodgsonTidemanApproximation::METHOD_NAME[0],
+        FirstPastThePost::METHOD_NAME[0],
     ];
 
     protected ?array $_Stats = null;

--- a/lib/Algo/Methods/STV/CPO_STV.php
+++ b/lib/Algo/Methods/STV/CPO_STV.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace CondorcetPHP\Condorcet\Algo\Methods\STV;
 
 use CondorcetPHP\Condorcet\Algo\Method;
-use CondorcetPHP\Condorcet\Algo\Methods\RankedPairs\RankedPairsMargin;
+use CondorcetPHP\Condorcet\Algo\Methods\Schulze\SchulzeMargin;
 use CondorcetPHP\Condorcet\Dev\CondorcetDocumentationGenerator\CondorcetDocAttributes\{Description, Example, FunctionReturn, PublicAPI, Related};
 use CondorcetPHP\Condorcet\Algo\Tools\Combinations;
 use CondorcetPHP\Condorcet\Algo\Tools\StvQuotas;
@@ -29,7 +29,7 @@ class CPO_STV extends SingleTransferableVote
     public const METHOD_NAME = ['CPO STV', 'CPO_STV', 'CPO-STV', 'CPO', 'Comparison of Pairs of Outcomes by the Single Transferable Vote', 'Tideman STV'];
 
     public static StvQuotas $optionQuota = StvQuotas::HAGENBACH_BISCHOFF;
-    public static string $optionCondorcetCompletionMethod = RankedPairsMargin::class;
+    public static string $optionCondorcetCompletionMethod = SchulzeMargin::class;
 
     protected ?array $_Stats = null;
 

--- a/lib/Algo/Methods/STV/CPO_STV.php
+++ b/lib/Algo/Methods/STV/CPO_STV.php
@@ -52,7 +52,7 @@ class CPO_STV extends SingleTransferableVote
         $this->votesNeededToWin = \round(self::$optionQuota->getQuota($this->getElection()->sumValidVotesWeightWithConstraints(), $this->getElection()->getNumberOfSeats()), self::DECIMAL_PRECISION, \PHP_ROUND_HALF_DOWN);
 
         // Compute Initial Score
-        $this->initialScoreTable = $this->makeScore([],[],[]);
+        $this->initialScoreTable = $this->makeScore();
 
         // Candidates elected from first round
         foreach ($this->initialScoreTable as $candidateKey => $oneScore) :
@@ -114,7 +114,7 @@ class CPO_STV extends SingleTransferableVote
                 endforeach;
 
                 // Make score again
-                $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_exclusion'] = $this->makeScore([], [], $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded']);
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_exclusion'] = $this->makeScore(candidateEliminated: $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded']);
 
                 $surplusToTransfer = [];
                 $winnerToJoin = [];
@@ -131,7 +131,7 @@ class CPO_STV extends SingleTransferableVote
 
                 $winnerFromFirstRound = \array_keys($winnerToJoin);
 
-                $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_surplus'] = $winnerToJoin + $this->makeScore($surplusToTransfer, $winnerFromFirstRound, $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'], 2);
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_surplus'] = $winnerToJoin + $this->makeScore($surplusToTransfer, $winnerFromFirstRound, $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded']);
 
                 // Outcome Score
                 $MainOutcomeScore = 0;
@@ -193,7 +193,9 @@ class CPO_STV extends SingleTransferableVote
             $completionMethodResult = $winnerOutcomeElection->getResult(self::$optionCondorcetCompletionMethod);
             $this->completionMethodPairwise = $winnerOutcomeElection->getExplicitPairwise();
             $this->completionMethodStats = $completionMethodResult->getStats();
-            $this->condorcetWinnerOutcome = (int) $completionMethodResult->getWinner(self::$optionCondorcetCompletionMethod)->getName();
+
+            $condorcetWinnerOutcome = $completionMethodResult->getWinner(self::$optionCondorcetCompletionMethod);
+            $this->condorcetWinnerOutcome = (int) (!\is_array($condorcetWinnerOutcome) ? $condorcetWinnerOutcome->getName() : reset($condorcetWinnerOutcome)->getName());
     }
 
     protected function getStats(): array

--- a/lib/Algo/Methods/STV/CPO_STV.php
+++ b/lib/Algo/Methods/STV/CPO_STV.php
@@ -95,6 +95,8 @@ class CPO_STV extends SingleTransferableVote
 
     protected function compareOutcomes (): void
     {
+        $election = $this->getElection();
+
         foreach ($this->outcomes as $MainOutcomeKey => $MainOutcomeR) :
             foreach ($this->outcomes as $ComparedOutcomeKey => $ComparedOutcomeR) :
                 $outcomeComparisonKey = $this->getOutcomesComparisonKey($MainOutcomeKey, $ComparedOutcomeKey);
@@ -107,7 +109,7 @@ class CPO_STV extends SingleTransferableVote
                 $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'] = [];
 
                 // Eliminate Candidates from Outcome
-                foreach (\array_keys($this->getElection()->getCandidatesList()) as $candidateKey) :
+                foreach (\array_keys($election->getCandidatesList()) as $candidateKey) :
                     if (!\in_array($candidateKey, $MainOutcomeR, true) && !\in_array($candidateKey, $ComparedOutcomeR, true)) :
                         $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'][] = $candidateKey;
                     endif;
@@ -200,22 +202,24 @@ class CPO_STV extends SingleTransferableVote
 
     protected function getStats(): array
     {
+        $election = $this->getElection();
+
         $stats = ['votes_needed_to_win' => $this->votesNeededToWin];
 
-        $changeKeyToCandidateAndSortByName = function (array $arr): array {
+        $changeKeyToCandidateAndSortByName = function (array $arr, Election $election): array {
             $r = [];
             foreach ($arr as $candidateKey => $value) :
-                $r[(string) $this->getElection()->getCandidateObjectFromKey($candidateKey)] = $value;
+                $r[(string) $election->getCandidateObjectFromKey($candidateKey)] = $value;
             endforeach;
 
             \ksort($r, \SORT_NATURAL);
             return $r;
         };
 
-        $changeValueToCandidateAndSortByName = function (array $arr): array {
+        $changeValueToCandidateAndSortByName = function (array $arr, Election $election): array {
             $r = [];
             foreach ($arr as $candidateKey) :
-                $r[] = (string) $this->getElection()->getCandidateObjectFromKey($candidateKey);
+                $r[] = (string) $election->getCandidateObjectFromKey($candidateKey);
             endforeach;
 
             \sort($r, \SORT_NATURAL);
@@ -223,26 +227,26 @@ class CPO_STV extends SingleTransferableVote
         };
 
         // Initial Scores Table
-        $stats['Initial Score Table'] = $changeKeyToCandidateAndSortByName($this->initialScoreTable);
+        $stats['Initial Score Table'] = $changeKeyToCandidateAndSortByName($this->initialScoreTable, $election);
 
         // Candidates Elected from first round
-        $stats['Candidates elected from first round'] = $changeValueToCandidateAndSortByName($this->candidatesElectedFromFirstRound);
+        $stats['Candidates elected from first round'] = $changeValueToCandidateAndSortByName($this->candidatesElectedFromFirstRound, $election);
 
         // Candidates Eliminated from first round
-        $stats['Candidates eliminated from first round'] = $changeValueToCandidateAndSortByName($this->candidatesEliminatedFromFirstRound);
+        $stats['Candidates eliminated from first round'] = $changeValueToCandidateAndSortByName($this->candidatesEliminatedFromFirstRound, $election);
 
         // Outcome
         foreach ($this->outcomes as $outcomeKey => $outcomeValue) :
-            $stats['Outcomes'][$outcomeKey] = $changeValueToCandidateAndSortByName($outcomeValue);
+            $stats['Outcomes'][$outcomeKey] = $changeValueToCandidateAndSortByName($outcomeValue, $election);
         endforeach;
 
         // Outcomes Comparison
         foreach ($this->outcomeComparisonTable as $octKey => $octValue) :
             foreach ($octValue as $octDetailsKey => $octDetailsValue) :
                 if ($octDetailsKey === 'candidates_excluded') :
-                    $stats['Outcomes Comparison'][$octKey][$octDetailsKey] = $changeValueToCandidateAndSortByName($octDetailsValue);
+                    $stats['Outcomes Comparison'][$octKey][$octDetailsKey] = $changeValueToCandidateAndSortByName($octDetailsValue, $election);
                 else :
-                    $stats['Outcomes Comparison'][$octKey][$octDetailsKey] = $changeKeyToCandidateAndSortByName($octDetailsValue);
+                    $stats['Outcomes Comparison'][$octKey][$octDetailsKey] = $changeKeyToCandidateAndSortByName($octDetailsValue, $election);
                 endif;
             endforeach;
         endforeach;

--- a/lib/Algo/Methods/STV/CPO_STV.php
+++ b/lib/Algo/Methods/STV/CPO_STV.php
@@ -19,6 +19,7 @@ use CondorcetPHP\Condorcet\Algo\Tools\Combinations;
 use CondorcetPHP\Condorcet\Algo\Tools\StvQuotas;
 use CondorcetPHP\Condorcet\Election;
 use CondorcetPHP\Condorcet\Vote;
+use stdClass;
 
 // Single transferable vote | https://en.wikipedia.org/wiki/CPO-STV
 class CPO_STV extends SingleTransferableVote
@@ -47,6 +48,8 @@ class CPO_STV extends SingleTransferableVote
 
     protected function compute (): void
     {
+        Vote::$cacheKey = new stdClass; // Performances
+
         $rank = 0;
 
         $this->votesNeededToWin = \round(self::$optionQuota->getQuota($this->getElection()->sumValidVotesWeightWithConstraints(), $this->getElection()->getNumberOfSeats()), self::DECIMAL_PRECISION, \PHP_ROUND_HALF_DOWN);
@@ -91,6 +94,8 @@ class CPO_STV extends SingleTransferableVote
 
         // Register result
         $this->_Result = $this->createResult($r);
+
+        Vote::$cacheKey = null; // Performances
     }
 
     protected function compareOutcomes (): void
@@ -171,7 +176,7 @@ class CPO_STV extends SingleTransferableVote
             $winnerOutcomeElection->allowsVoteWeight(true);
 
                 // Candidates
-                foreach (\array_keys($this->outcomes) as $oneOutcomeKey) :
+                foreach ($this->outcomes as $oneOutcomeKey => $outcomeValue) :
                     $winnerOutcomeElection->addCandidate((string) $oneOutcomeKey);
                 endforeach;
 

--- a/lib/Algo/Methods/STV/CPO_STV.php
+++ b/lib/Algo/Methods/STV/CPO_STV.php
@@ -1,0 +1,241 @@
+<?php
+/*
+    Part of CPO STV method Module - From the original Condorcet PHP
+
+    Condorcet PHP - Election manager and results calculator.
+    Designed for the Condorcet method. Integrating a large number of algorithms extending Condorcet. Expandable for all types of voting systems.
+
+    By Julien Boudry and contributors - MIT LICENSE (Please read LICENSE.txt)
+    https://github.com/julien-boudry/Condorcet
+*/
+declare(strict_types=1);
+
+namespace CondorcetPHP\Condorcet\Algo\Methods\STV;
+
+use CondorcetPHP\Condorcet\Algo\Method;
+use CondorcetPHP\Condorcet\Algo\Methods\RankedPairs\RankedPairsMargin;
+use CondorcetPHP\Condorcet\Dev\CondorcetDocumentationGenerator\CondorcetDocAttributes\{Description, Example, FunctionReturn, PublicAPI, Related};
+use CondorcetPHP\Condorcet\Algo\Tools\Combinations;
+use CondorcetPHP\Condorcet\Algo\Tools\StvQuotas;
+use CondorcetPHP\Condorcet\Election;
+use CondorcetPHP\Condorcet\Vote;
+
+// Single transferable vote | https://en.wikipedia.org/wiki/CPO-STV
+class CPO_STV extends SingleTransferableVote
+{
+    // Method Name
+    public const METHOD_NAME = ['CPO STV', 'CPO_STV', 'CPO-STV', 'Comparison of Pairs of Outcomes by the Single Transferable Vote', 'Tideman STV'];
+
+    public static StvQuotas $optionQuota = StvQuotas::HAGENBACH_BISCHOFF;
+    public static string $optionCondorcetCompletionMethod = RankedPairsMargin::class;
+
+    protected ?array $_Stats = null;
+
+    protected readonly array $outcomes;
+    protected readonly array $initialScoreTable;
+    protected array $candidatesElectedFromFirstRound = [];
+    protected array $outcomeComparisonTable = [];
+    protected readonly int $condorcetWinnerOutcome;
+    protected readonly array $completionMethodPairwise;
+    protected readonly array $completionMethodStats;
+
+
+/////////// COMPUTE ///////////
+
+    //:: Alternative Vote ALGORITHM. :://
+
+    protected function compute (): void
+    {
+        $result = [];
+        $rank = 0;
+
+        $candidatesList = \array_keys($this->getElection()->getCandidatesList());
+        $this->votesNeededToWin = \round(self::$optionQuota->getQuota($this->getElection()->sumValidVotesWeightWithConstraints(), $this->getElection()->getNumberOfSeats()), self::DECIMAL_PRECISION, \PHP_ROUND_HALF_DOWN);
+
+        // Compute Initial Score
+        $this->initialScoreTable = $this->makeScore([],[],[]);
+
+        // Candidates elected from first round
+        foreach ($this->initialScoreTable as $candidateKey => $oneScore) :
+            if ($oneScore >= $this->votesNeededToWin) :
+                $this->candidatesElectedFromFirstRound[] = $candidateKey;
+            endif;
+        endforeach;
+
+        $numberOfCandidatesNeeded = $this->getElection()->getNumberOfSeats() - count($this->candidatesElectedFromFirstRound);
+
+        $firstRoundEliminatedCandidates = \array_diff($candidatesList, $this->candidatesElectedFromFirstRound);
+
+        // Compute all possible Ranking
+        $this->outcomes = Combinations::compute($firstRoundEliminatedCandidates, $numberOfCandidatesNeeded, $this->candidatesElectedFromFirstRound);
+
+        foreach ($this->outcomes as $MainOutcomeKey => $MainOutcomeR) :
+            foreach ($this->outcomes as $ComparedOutcomeKey => $ComparedOutcomeR) :
+                $outcomeComparisonKey = $this->getOutcomesComparisonKey($MainOutcomeKey, $ComparedOutcomeKey);
+
+                if (    $MainOutcomeKey === $ComparedOutcomeKey ||
+                        \array_key_exists($outcomeComparisonKey, $this->outcomeComparisonTable)
+                    ) :
+                    continue;
+                endif;
+
+                $this->outcomeComparisonTable[$outcomeComparisonKey] = [];
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'] = [];
+
+                // Eliminate Candidates from Outcome
+                foreach ($candidatesList as $candidateKey) :
+                    if (!\in_array($candidateKey, $MainOutcomeR, true) && !\in_array($candidateKey, $ComparedOutcomeR, true)) :
+                        $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'][] = $candidateKey;
+                    endif;
+                endforeach;
+
+                // Make score again
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_exclusion'] = $this->makeScore([], [], $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded']);
+
+                $surplusToTransfer = [];
+                $winnerToJoin = [];
+                foreach($this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_exclusion'] as $candidateKey => $oneScore) :
+                    $surplus = $oneScore - $this->votesNeededToWin;
+
+                    if ($surplus >= 0 && \in_array($candidateKey, $MainOutcomeR, true) && \in_array($candidateKey,$ComparedOutcomeR, true)) :
+                        $surplusToTransfer[$candidateKey] ?? $surplusToTransfer[$candidateKey] = ['surplus' => 0, 'total' => 0];
+                        $surplusToTransfer[$candidateKey]['surplus'] += $surplus;
+                        $surplusToTransfer[$candidateKey]['total'] += $oneScore;
+                        $winnerToJoin[$candidateKey] = $this->votesNeededToWin;
+                    endif;
+                endforeach;
+
+                $winnerFromFirstRound = \array_keys($winnerToJoin);
+
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_surplus'] = $winnerToJoin + $this->makeScore($surplusToTransfer, $winnerFromFirstRound, $this->outcomeComparisonTable[$outcomeComparisonKey]['candidates_excluded'], 2);
+
+                // Outcome Score
+                $MainOutcomeScore = 0;
+                $ComparedOutcomeScore = 0;
+
+                foreach ($this->outcomeComparisonTable[$outcomeComparisonKey]['scores_after_surplus'] as $candidateKey => $candidateScore) :
+                    if (in_array($candidateKey, $MainOutcomeR, true)) :
+                        $MainOutcomeScore += $candidateScore;
+                    endif;
+
+                    if (in_array($candidateKey, $ComparedOutcomeR, true)) :
+                        $ComparedOutcomeScore += $candidateScore;
+                    endif;
+                endforeach;
+
+                $this->outcomeComparisonTable[$outcomeComparisonKey]['outcomes_scores'] = [$MainOutcomeKey => $MainOutcomeScore, $ComparedOutcomeKey => $ComparedOutcomeScore];
+
+            endforeach;
+        endforeach;
+
+        // Chose Outcome with Condorcet
+        $winnerOutcomeElection = new Election;
+        $winnerOutcomeElection->setImplicitRanking(false);
+        $winnerOutcomeElection->allowsVoteWeight(true);
+
+            // Candidates
+            foreach (\array_keys($this->outcomes) as $oneOutcomeKey) :
+                $winnerOutcomeElection->addCandidate((string) $oneOutcomeKey);
+            endforeach;
+
+            // Votes
+            $coef = Method::DECIMAL_PRECISION ** 10 ; # Actually, vote weight does not support float
+            foreach ($this->outcomeComparisonTable as $comparison) :
+                ($vote1 = new Vote([
+                    (string) $key = \array_key_first($comparison['outcomes_scores']),
+                    (string) \array_key_last($comparison['outcomes_scores'])
+                ]))->setWeight((int) ($comparison['outcomes_scores'][$key] * $coef));
+
+                ($vote2 = new Vote([
+                    (string) $key = \array_key_last($comparison['outcomes_scores']),
+                    (string) \array_key_first($comparison['outcomes_scores'])
+                ]))->setWeight((int) ($comparison['outcomes_scores'][$key] * $coef));
+
+                $winnerOutcomeElection->addVote($vote1);
+                $winnerOutcomeElection->addVote($vote2);
+            endforeach;
+
+        // Chose Outcome
+        $completionMethodResult = $winnerOutcomeElection->getResult(self::$optionCondorcetCompletionMethod);
+        $this->completionMethodPairwise = $winnerOutcomeElection->getExplicitPairwise();
+        $this->completionMethodStats = $completionMethodResult->getStats();
+
+        $this->condorcetWinnerOutcome = (int) $completionMethodResult->getWinner(self::$optionCondorcetCompletionMethod)->getName();
+        $winnerOutcome = $this->outcomes[$this->condorcetWinnerOutcome];
+
+        // Sort Outcome using originals scores
+        \usort($winnerOutcome, fn (float $a, float $b): int => $this->initialScoreTable[$b] <=> $this->initialScoreTable[$a]);
+
+        // Results: Format Ranks
+        $rank = 1;
+        $r = [];
+        foreach ($winnerOutcome as $candidateKey) :
+            $r[$rank++] = $candidateKey;
+        endforeach;
+
+        // Register result
+        $this->_Result = $this->createResult($r);
+    }
+
+    protected function getOutcomesComparisonKey (int $MainOutcomeKey, int $ComparedOutcomeKey): string
+    {
+        $minOutcome = (string) \min($MainOutcomeKey, $ComparedOutcomeKey);
+        $maxOutcome = (string) \max($MainOutcomeKey, $ComparedOutcomeKey);
+
+        return 'Outcome N° '.$minOutcome.' compared to Outcome N° '.$maxOutcome;
+    }
+
+    protected function getStats(): array
+    {
+        $stats = [];
+
+        $changeKeyToCandidateAndSortByName = function (array $arr, Election $election): array {
+            $r = [];
+            foreach ($arr as $candidateKey => $value) :
+                $r[(string) $election->getCandidateObjectFromKey($candidateKey)] = $value;
+            endforeach;
+
+            \ksort($r, \SORT_NATURAL);
+            return $r;
+        };
+
+        $changeValueToCandidateandSortByName = function (array $arr, Election $election): array {
+            $r = [];
+            foreach ($arr as $candidateKey) :
+                $r[] = (string) $election->getCandidateObjectFromKey($candidateKey);
+            endforeach;
+
+            \sort($r, \SORT_NATURAL);
+            return $r;
+        };
+
+        // Initial Scores Table
+        $stats['Initial Score Table'] = $changeKeyToCandidateAndSortByName($this->initialScoreTable, $this->getElection());
+
+        // Outcome
+        foreach ($this->outcomes as $outcomeKey => $outcomeValue) :
+            $stats['Outcomes'][$outcomeKey] = $changeValueToCandidateandSortByName($outcomeValue, $this->getElection());
+        endforeach;
+
+        // Outcomes Comparison
+        foreach ($this->outcomeComparisonTable as $octKey => $octValue) :
+            foreach ($octValue as $octDetailsKey => $octDetailsValue) :
+                if ($octDetailsKey === 'candidates_excluded') :
+                    $stats['Outcomes Comparison'][$octKey][$octDetailsKey] = $changeValueToCandidateandSortByName($octDetailsValue, $this->getElection());
+                else :
+                    $stats['Outcomes Comparison'][$octKey][$octDetailsKey] = $changeKeyToCandidateAndSortByName($octDetailsValue, $this->getElection());
+                endif;
+            endforeach;
+        endforeach;
+
+        // Completion method Stats
+        $stats['Condorcet Completion Method Stats'] = [
+            'Pairwise' => $this->completionMethodPairwise,
+            'Stats' => $this->completionMethodStats,
+        ];
+
+        // Return
+        return $stats;
+    }
+
+}

--- a/lib/Algo/Methods/STV/SingleTransferableVote.php
+++ b/lib/Algo/Methods/STV/SingleTransferableVote.php
@@ -107,14 +107,14 @@ class SingleTransferableVote extends Method implements MethodInterface
 
         foreach ($election->getVotesManager()->getVotesValidUnderConstraintGenerator() as $oneVote) :
 
-            $weight = $oneVote->getWeight($this->getElection());
+            $weight = $oneVote->getWeight($election);
 
             $winnerBonusWeight = 0;
             $winnerBonusKey = null;
             $LoserBonusWeight = 0;
 
             $firstRank = true;
-            foreach ($oneVote->getContextualRanking($this->getElection()) as $oneRank) :
+            foreach ($oneVote->getContextualRanking($election) as $oneRank) :
                 foreach ($oneRank as $oneCandidate) :
                     if (\count($oneRank) !== 1): break; endif;
 

--- a/lib/Algo/Methods/STV/SingleTransferableVote.php
+++ b/lib/Algo/Methods/STV/SingleTransferableVote.php
@@ -90,7 +90,7 @@ class SingleTransferableVote extends Method implements MethodInterface
         $this->_Result = $this->createResult($result);
     }
 
-    protected function makeScore (array $surplus, array $candidateElected, array $candidateEliminated): array
+    protected function makeScore (array $surplus = [], array $candidateElected = [], array $candidateEliminated = []): array
     {
         $scoreTable = [];
 

--- a/lib/Algo/Methods/STV/SingleTransferableVote.php
+++ b/lib/Algo/Methods/STV/SingleTransferableVote.php
@@ -114,7 +114,7 @@ class SingleTransferableVote extends Method implements MethodInterface
             $LoserBonusWeight = 0;
 
             $firstRank = true;
-            foreach ($oneVote->getContextualRanking($election) as $oneRank) :
+            foreach ($oneVote->getContextualRanking($election, false) as $oneRank) :
                 foreach ($oneRank as $oneCandidate) :
                     if (\count($oneRank) !== 1): break; endif;
 

--- a/lib/Algo/Methods/STV/SingleTransferableVote.php
+++ b/lib/Algo/Methods/STV/SingleTransferableVote.php
@@ -15,6 +15,8 @@ namespace CondorcetPHP\Condorcet\Algo\Methods\STV;
 use CondorcetPHP\Condorcet\Dev\CondorcetDocumentationGenerator\CondorcetDocAttributes\{Description, Example, FunctionReturn, PublicAPI, Related};
 use CondorcetPHP\Condorcet\Algo\{Method, MethodInterface};
 use CondorcetPHP\Condorcet\Algo\Tools\StvQuotas;
+use CondorcetPHP\Condorcet\Vote;
+use stdClass;
 
 // Single transferable vote | https://en.wikipedia.org/wiki/Single_transferable_vote
 class SingleTransferableVote extends Method implements MethodInterface
@@ -38,6 +40,7 @@ class SingleTransferableVote extends Method implements MethodInterface
     protected function compute (): void
     {
         $election = $this->getElection();
+        Vote::$cacheKey = new stdClass; // Performances
 
         $result = [];
         $rank = 0;
@@ -90,6 +93,8 @@ class SingleTransferableVote extends Method implements MethodInterface
         endwhile;
 
         $this->_Result = $this->createResult($result);
+
+        Vote::$cacheKey = null; // Performances
     }
 
     protected function makeScore (array $surplus = [], array $candidateElected = [], array $candidateEliminated = []): array

--- a/lib/Algo/Methods/STV/SingleTransferableVote.php
+++ b/lib/Algo/Methods/STV/SingleTransferableVote.php
@@ -28,7 +28,7 @@ class SingleTransferableVote extends Method implements MethodInterface
 
     protected ?array $_Stats = null;
 
-    protected readonly float $votesNeededToWin;
+    protected float $votesNeededToWin;
 
 
 /////////// COMPUTE ///////////

--- a/lib/Algo/Methods/STV/SingleTransferableVote.php
+++ b/lib/Algo/Methods/STV/SingleTransferableVote.php
@@ -35,8 +35,6 @@ class SingleTransferableVote extends Method implements MethodInterface
 
 /////////// COMPUTE ///////////
 
-    //:: Alternative Vote ALGORITHM. :://
-
     protected function compute (): void
     {
         $election = $this->getElection();

--- a/lib/Algo/Pairwise.php
+++ b/lib/Algo/Pairwise.php
@@ -180,7 +180,7 @@ class Pairwise implements \ArrayAccess, \Iterator
     {
         $election = $this->getElection();
 
-        $vote_ranking = $oneVote->getContextualRanking($election);
+        $vote_ranking = $oneVote->getContextualRanking($election, false);
         $voteWeight = $oneVote->getWeight($election);
 
         $vote_candidate_list = [];

--- a/lib/Algo/Tools/Combinations.php
+++ b/lib/Algo/Tools/Combinations.php
@@ -10,15 +10,33 @@ declare(strict_types=1);
 
 namespace CondorcetPHP\Condorcet\Algo\Tools;
 
+use SplFixedArray;
+
 class Combinations
 {
-    public static function compute (array $values, int $length, array $append_before = []): array
+    public static function compute (array $values, int $length, array $append_before = []): SplFixedArray
     {
         $count = \count($values);
         $size = 2 ** $count;
         $keys = \array_keys($values);
-        $return = [];
 
+        // Number of combinations
+        $a = 1;
+        for ($i = $count ; $i > ($count - $length) ; $i--) :
+            $a = $a * $i;
+        endfor;
+
+        $b = 1;
+        for ($i = $length ; $i > 0 ; $i--) :
+            $b = $b * $i;
+        endfor;
+
+        $combinations_count = (int) $a / $b;
+
+        // Get the combinations
+        $return = new SplFixedArray($combinations_count);
+
+        $arrKey = 0;
         for ($i = 0; $i < $size; $i++) :
             $b = \sprintf("%0" . $count . "b", $i);
             $out = [];
@@ -30,7 +48,7 @@ class Combinations
             endfor;
 
             if (count($out) === $length) :
-                 $return[] = \array_merge($append_before, $out);
+                 $return[$arrKey++] = \array_merge($append_before, $out);
             endif;
         endfor;
 

--- a/lib/Algo/Tools/Combinations.php
+++ b/lib/Algo/Tools/Combinations.php
@@ -1,0 +1,39 @@
+<?php
+/*
+    Condorcet PHP - Election manager and results calculator.
+    Designed for the Condorcet method. Integrating a large number of algorithms extending Condorcet. Expandable for all types of voting systems.
+
+    By Julien Boudry and contributors - MIT LICENSE (Please read LICENSE.txt)
+    https://github.com/julien-boudry/Condorcet
+*/
+declare(strict_types=1);
+
+namespace CondorcetPHP\Condorcet\Algo\Tools;
+
+class Combinations
+{
+    public static function compute (array $values, int $length, array $append_before = []): array
+    {
+        $count = \count($values);
+        $size = 2 ** $count;
+        $keys = \array_keys($values);
+        $return = [];
+
+        for ($i = 0; $i < $size; $i++) :
+            $b = \sprintf("%0" . $count . "b", $i);
+            $out = [];
+
+            for ($j = 0; $j < $count; $j++) :
+                if ($b[$j] == '1') :
+                    $out[$keys[$j]] = $values[$keys[$j]];
+                endif;
+            endfor;
+
+            if (count($out) === $length) :
+                 $return[] = \array_merge($append_before, $out);
+            endif;
+        endfor;
+
+        return $return;
+    }
+}

--- a/lib/Algo/Tools/Permutations.php
+++ b/lib/Algo/Tools/Permutations.php
@@ -10,11 +10,14 @@ declare(strict_types=1);
 
 namespace CondorcetPHP\Condorcet\Algo\Tools;
 
+use SplFixedArray;
+
 // Thanks to Jorge Gomes @cyberkurumin
 class Permutations
 {
     protected readonly int $arr_count;
-    protected array $results = [];
+    protected SplFixedArray $results;
+    protected int $arrKey = 0;
 
     public static function countPossiblePermutations (int $candidatesNumber): int
     {
@@ -30,11 +33,12 @@ class Permutations
     public function __construct (int $arr_count)
     {
         $this->arr_count = $arr_count;
+        $this->results = new SplFixedArray(self::countPossiblePermutations($this->arr_count));
     }
 
-    public function getResults (): array
+    public function getResults (): SplFixedArray
     {
-        if (empty($this->results)) :
+        if ($this->arrKey === 0) :
             $this->_exec(
                 $this->_permute( $this->createCandidates() )
             );
@@ -78,7 +82,7 @@ class Permutations
             $r = [...[0=>null],...$i];
             unset($r[0]);
 
-            $this->results[] = $r;
+            $this->results[$this->arrKey++] = $r;
         endif;
     }
 

--- a/lib/Algo/Tools/Permutations.php
+++ b/lib/Algo/Tools/Permutations.php
@@ -47,11 +47,11 @@ class Permutations
         return $this->results;
     }
 
-    public function writeResults (string $path): void {
-        $f = new \SplFileObject($path,'w+');
+    public function writeResults (\SplFileObject $file): void {
+        $file->rewind();
 
         foreach ($this->getResults() as $oneResult) :
-            $f->fputcsv($oneResult);
+            $file->fputcsv($oneResult);
         endforeach;
     }
 

--- a/lib/Algo/Tools/TieBreakersCollection.php
+++ b/lib/Algo/Tools/TieBreakersCollection.php
@@ -47,4 +47,27 @@ abstract class TieBreakersCollection
 
         return (\count($tooKeep) > 0) ? $tooKeep : $candidatesKeys;
     }
+
+    public static function tieBreakerWithAnotherMethods (Election $election, array $methods, array $candidatesKeys): array
+    {
+        foreach ($methods as $oneMethod) :
+            $tooKeep = [];
+
+            $methodResults = $election->getResult($oneMethod)->getResultAsInternalKey();
+
+            foreach ($methodResults as $rankKey => $rankValue) :
+                foreach ($rankValue as $oneCandidateKey) :
+                    if (\in_array($oneCandidateKey, $candidatesKeys, true)) :
+                        $tooKeep[] = $oneCandidateKey;
+                    endif;
+                endforeach;
+
+                if (\count($tooKeep) > 0 && \count($tooKeep) !== \count($candidatesKeys)) :
+                    return $tooKeep;
+                endif;
+            endforeach;
+        endforeach;
+
+        return $candidatesKeys;
+    }
 }

--- a/lib/Condorcet.php
+++ b/lib/Condorcet.php
@@ -35,6 +35,7 @@ Condorcet::addMethod( Algo\Methods\Schulze\SchulzeRatio::class );
 
     // Proportional Methods
 Condorcet::addMethod( Algo\Methods\STV\SingleTransferableVote::class );
+Condorcet::addMethod( Algo\Methods\STV\CPO_STV::class );
 
 // Set the default Condorcet Class algorithm
 Condorcet::setDefaultMethod('Schulze');

--- a/lib/Console/Commands/ElectionCommand.php
+++ b/lib/Console/Commands/ElectionCommand.php
@@ -63,6 +63,9 @@ class ElectionCommand extends Command
     protected TableStyle $centerPadTypeStyle;
     protected Terminal $terminal;
 
+    // Debug
+    public static ?string $forceIniMemoryLimitTo = null;
+
     protected function configure (): void
     {
         $this->setHelp('This command takes candidates and votes as input. The output is the result of that election.')
@@ -155,6 +158,7 @@ class ElectionCommand extends Command
                             description: 'Methods to output',
             )
         ;
+
     }
 
     protected function initialize (InputInterface $input, OutputInterface $output): void
@@ -173,6 +177,7 @@ class ElectionCommand extends Command
 
         // Parameters
         $this->setUpParameters($input);
+        $this->ini_memory_limit = (self::$forceIniMemoryLimitTo === null) ? \ini_get('memory_limit') : self::$forceIniMemoryLimitTo;
 
         // Non-interactive candidates
         $this->candidates = $input->getOption('candidates') ?? null;
@@ -651,7 +656,7 @@ class ElectionCommand extends Command
             $election = $this->election;
             $SQLitePath = &$this->SQLitePath;
 
-            $memory_limit = (int) \preg_replace('`[^0-9]`', '', \ini_get('memory_limit'));
+            $memory_limit = (int) \preg_replace('`[^0-9]`', '', $this->ini_memory_limit);
             $vote_in_memory_limit = self::$VotesPerMB * $memory_limit;
 
             $callBack = static function (int $inserted_votes_count) use ($election, $vote_in_memory_limit, &$SQLitePath): bool {

--- a/lib/Console/Commands/ElectionCommand.php
+++ b/lib/Console/Commands/ElectionCommand.php
@@ -365,7 +365,7 @@ class ElectionCommand extends Command
                     ->setRows($rows)
 
                     ->setColumnStyle(0,$this->centerPadTypeStyle)
-                    ->setColumnWidth(0, 20)
+                    ->setColumnWidth(0, 0)
                     ->render()
                 ;
             endif;
@@ -377,9 +377,9 @@ class ElectionCommand extends Command
 
                 ->setColumnStyle(0,$this->centerPadTypeStyle)
 
-                ->setColumnWidth(0, 10)
-                ->setColumnWidth(1, 20)
-                ->setColumnMaxWidth(1, ($this->terminal->getWidth() - 20))
+                ->setColumnWidth(0, 30)
+                ->setColumnWidth(1, 100)
+                ->setColumnMaxWidth(1, ($this->terminal->getWidth() - 30))
 
                 ->render()
             ;

--- a/lib/Console/Commands/ElectionCommand.php
+++ b/lib/Console/Commands/ElectionCommand.php
@@ -352,6 +352,8 @@ class ElectionCommand extends Command
                 foreach ($options as $key => $value) :
                     if ($value instanceof \BackedEnum) :
                         $value = $value->value;
+                    elseif (\is_array($value)) :
+                        $value = implode(' / ', $value);
                     endif;
 
                     $rows[] = [$key.':', $value];

--- a/lib/ElectionProcess/CandidatesProcess.php
+++ b/lib/ElectionProcess/CandidatesProcess.php
@@ -94,7 +94,7 @@ trait CandidatesProcess
         bool $strictMode = true
     ): bool
     {
-        return $strictMode ? \in_array(needle: $candidate, haystack: $this->_Candidates, strict: true): \in_array(needle: (string) $candidate, haystack: $this->_Candidates);
+        return $strictMode ? \in_array(needle: $candidate, haystack: $this->_Candidates, strict: true) : \in_array(needle: (string) $candidate, haystack: $this->_Candidates, strict: false);
     }
 
     #[PublicAPI]

--- a/lib/ElectionProcess/ResultsProcess.php
+++ b/lib/ElectionProcess/ResultsProcess.php
@@ -194,7 +194,7 @@ trait ResultsProcess
         #[FunctionParameter('Option name')]
         string $optionName,
         #[FunctionParameter('Option Value')]
-        \BackedEnum|int $optionValue): bool
+        \BackedEnum|int|string $optionValue): bool
     {
         if ($method = Condorcet::getMethodClass($method)) :
             $method::setOption($optionName, $optionValue);

--- a/lib/Vote.php
+++ b/lib/Vote.php
@@ -159,12 +159,15 @@ class Vote implements \Iterator, \Stringable
     #[Description("Get the actual Ranking of this Vote.")]
     #[FunctionReturn("Multidimenssionnal array populated by Candidate object.")]
     #[Related("Vote::setRanking")]
-    public function getRanking (): array
+    public function getRanking (
+        #[FunctionParameter('Sort Candidate in a Rank by name. Useful for performant internal calls from methods.')]
+        bool $sortCandidatesInRank = true
+    ): array
     {
         $r = $this->_ranking;
 
         foreach ($r as &$oneRank) :
-            if (count($oneRank) > 1) :
+            if ($sortCandidatesInRank && count($oneRank) > 1) :
                 sort($oneRank, \SORT_STRING);
             endif;
         endforeach;
@@ -234,7 +237,7 @@ class Vote implements \Iterator, \Stringable
     {
         $list = [];
 
-        foreach ($this->getRanking() as $rank) :
+        foreach ($this->getRanking(false) as $rank) :
             foreach ($rank as $oneCandidate) :
                 $list[] = $oneCandidate;
             endforeach;
@@ -265,7 +268,7 @@ class Vote implements \Iterator, \Stringable
         $candidates_list = $election->getCandidatesList();
         $candidates_count = $election->countCandidates();
 
-        $newRanking = $this->computeContextualRankingWithoutImplicit($this->getRanking(), $election, $countContextualCandidate);
+        $newRanking = $this->computeContextualRankingWithoutImplicit($this->getRanking(false), $election, $countContextualCandidate);
 
         if ($election->getImplicitRankingRule() && $countContextualCandidate < $candidates_count) :
             $last_rank = [];


### PR DESCRIPTION
#84

- [x] Base complete implementation
- [ ] Find more reliable results tests to implement (many more)

- [x] Maybe the use of Schulze method instead of Tideman method (Ranked pairs) should be better for performance and candidate limits.

- [x] Find a better and less arbitrary method to choose the best outcome when the advanced Condorcet methods return two candidates at first rank. Can be chained methods? Try to use TieBreakerCollection?
- [x] Optimize and verify performance with many candidates, especially where they are many candidates for a low number of seats.
- [x] ~~Don't like `\sprintf` on Combinations class, remove it~~

- [x] Write documentation of VOTING_METHOD.md

