### PR TITLE
Dev 4.5

### DIFF
--- a/Tests/src/Algo/Pairwise/FilteredPairwiseTest.php
+++ b/Tests/src/Algo/Pairwise/FilteredPairwiseTest.php
@@ -278,4 +278,69 @@ class FilteredPairwiseTest extends TestCase
         self::assertArrayHasKey('B', $filteredPairwise->getExplicitPairwise());
         self::assertArrayHasKey('C', $filteredPairwise->getExplicitPairwise());
     }
+
+    public function testFilteredPairwiseResults_2(): void
+    {
+        $this->election1->removeAllVotes();
+        $this->election1->allowsVoteWeight(true);
+
+        $this->election1->parseVotes('
+            A > B > C
+            tag1 || B > C > A
+            tag2 || A > B > C
+            tag1, tag2 || C > B > A *2
+        ');
+
+
+        $filteredWithBothTags = $this->election1->getExplicitFilteredPairwiseByTags(['tag1','tag2'], 2);
+
+
+        // Test $filteredwithBothTags
+        self::assertSame(
+            expected: [
+                'A' => [
+                    'win' => [
+                        'B' => 0,
+                        'C' => 0,
+                    ],
+                    'null' => [
+                        'B' => 0,
+                        'C' => 0,
+                    ],
+                    'lose' => [
+                        'B' => 2,
+                        'C' => 2,
+                    ],
+                ],
+                'B' => [
+                    'win' => [
+                        'A' => 2,
+                        'C' => 0,
+                    ],
+                    'null' => [
+                        'A' => 0,
+                        'C' => 0,
+                    ],
+                    'lose' => [
+                        'A' => 0,
+                        'C' => 2,
+                    ],
+                ],
+                'C' => [
+                    'win' => [
+                        'A' => 2,
+                        'B' => 2,
+                    ],
+                    'null' => [
+                        'A' => 0,
+                        'B' => 0,
+                    ],
+                    'lose' => [
+                        'A' => 0,
+                        'B' => 0,
+                    ],
+                ]],
+            actual: $filteredWithBothTags
+        );
+    }
 }

--- a/src/Algo/Pairwise/FilteredPairwise.php
+++ b/src/Algo/Pairwise/FilteredPairwise.php
@@ -20,10 +20,12 @@ class FilteredPairwise extends Pairwise
     protected readonly array $candidates;
     public readonly ?array $tags;
 
+    const ALL = 2;
+
     public function __construct(
         Election $link,
         array|string|null $tags = null,
-        public readonly bool $withTags = true
+        public readonly int|bool $withTags = true
     ) {
         $this->tags = VoteUtil::tagsConvert($tags);
 

--- a/src/Algo/Pairwise/FilteredPairwise.php
+++ b/src/Algo/Pairwise/FilteredPairwise.php
@@ -20,8 +20,6 @@ class FilteredPairwise extends Pairwise
     protected readonly array $candidates;
     public readonly ?array $tags;
 
-    const ALL = 2;
-
     public function __construct(
         Election $link,
         array|string|null $tags = null,

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -118,17 +118,26 @@ class VotesManager extends ArrayManager
         }
     }
 
-    protected function getPartialVotesListGenerator(array $tags, bool $with): \Generator
+    protected function getPartialVotesListGenerator(array $tags, int|bool $with): \Generator
     {
+        $tagsfound = 0;
         foreach ($this as $voteKey => $vote) {
             $noOne = true;
-            foreach ($tags as $oneTag) {
-                if (($oneTag === $voteKey) || \in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
-                    if ($with) {
-                        yield $voteKey => $vote;
-                        break;
-                    } else {
-                        $noOne = false;
+            if ($min == 0 or $min == 1) {
+                foreach ($tags as $oneTag) {
+                    if (($oneTag === $voteKey) || \in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
+                        if ($with == 1) {
+                            yield $voteKey => $vote;
+                            break;
+                        } elseif ($with > 1) {
+                            $tagsfound++;
+                            if ($tagsfound >= $with) {
+                                yield $voteKey => $vote;
+                                break;
+                            }
+                        } else {
+                            $noOne = false;
+                        }
                     }
                 }
             }
@@ -165,7 +174,7 @@ class VotesManager extends ArrayManager
         }
     }
 
-    public function getVotesValidUnderConstraintGenerator(?array $tags = null, bool $with = true): \Generator
+    public function getVotesValidUnderConstraintGenerator(?array $tags = null, int|bool $with = true): \Generator
     {
         $election = $this->getElection();
         $generator = ($tags === null) ? $this->getFullVotesListGenerator() : $this->getPartialVotesListGenerator($tags, $with);

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -120,8 +120,9 @@ class VotesManager extends ArrayManager
 
     protected function getPartialVotesListGenerator(array $tags, int|bool $with): \Generator
     {
-        $tagsfound = 0;
+
         foreach ($this as $voteKey => $vote) {
+            $tagsfound = 0;
             $noOne = true;
             if ($min == 0 or $min == 1) {
                 foreach ($tags as $oneTag) {

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -124,26 +124,25 @@ class VotesManager extends ArrayManager
         foreach ($this as $voteKey => $vote) {
             $tagsfound = 0;
             $noOne = true;
-            if ($min == 0 or $min == 1) {
-                foreach ($tags as $oneTag) {
-                    if (($oneTag === $voteKey) || \in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
-                        if ($with == 1) {
+            foreach ($tags as $oneTag) {
+                if (($oneTag === $voteKey) || \in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
+                    if ($with == 1) {
+                        yield $voteKey => $vote;
+                        break;
+                    } elseif ($with > 1) {
+                        $tagsfound++;
+                        if ($tagsfound >= $with) {
                             yield $voteKey => $vote;
                             break;
-                        } elseif ($with > 1) {
-                            $tagsfound++;
-                            if ($tagsfound >= $with) {
-                                yield $voteKey => $vote;
-                                break;
-                            }
-                        } else {
-                            $noOne = false;
                         }
+                    } else {
+                        $noOne = false;
                     }
                 }
             }
 
-            if (!$with && $noOne) {
+
+            if ($with == 0 && $noOne) {
                 yield $voteKey => $vote;
             }
         }

--- a/src/ElectionProcess/ResultsProcess.php
+++ b/src/ElectionProcess/ResultsProcess.php
@@ -183,7 +183,7 @@ trait ResultsProcess
         #[FunctionParameter('Tags as string separated by commas or array')]
         array|string $tags,
         #[FunctionParameter('Votes with these tags or without')]
-        bool $with = true
+        int|bool $with = true
     ): FilteredPairwise {
         return new FilteredPairwise($this, $tags, $with);
     }
@@ -204,8 +204,8 @@ trait ResultsProcess
     public function getExplicitFilteredPairwiseByTags(
         #[FunctionParameter('Tags as string separated by commas or array')]
         array|string $tags,
-        #[FunctionParameter('Votes with these tags or without')]
-        bool $with = true
+        #[FunctionParameter('Minimum number of specified tags that votes must include, or 0 for only votes without any specified tags')]
+        bool|int $with = 1
     ): array {
         return $this->getFilteredPairwiseByTags($tags, $with)->getExplicitPairwise();
     }


### PR DESCRIPTION
I realized that `getExplicitPairwise()` and `getExplicitFilteredPairwise` gets pairwise from votes that have _any_ of the specified tags (not all). I decided to change this so that a minimum number of tags can be specified. I did everything required to do this.

There is a new test in `FilteredPairwiseTests` to test that this is working. It seems to be working properly.

I recommend a squash merge, as this is a mess of small commits, some of which just revert each-other.