### PR TITLE
FilteredPairwise now accepts a minimum number of tags.

### DIFF
--- a/Tests/src/Algo/Pairwise/FilteredPairwiseTest.php
+++ b/Tests/src/Algo/Pairwise/FilteredPairwiseTest.php
@@ -250,7 +250,7 @@ class FilteredPairwiseTest extends TestCase
 
         self::assertSame($explicitOriginalFromFilteredPairwise, $filteredPairwise->getExplicitPairwise());
         self::assertSame(['tag1'], $filteredPairwise->tags);
-        self::assertSame(1, $filteredPairwise->withTags);
+        self::assertTrue($filteredPairwise->withTags);
     }
 
     public function testModifyFilteredPairwise(): void
@@ -292,7 +292,7 @@ class FilteredPairwiseTest extends TestCase
         ');
 
 
-        $filteredWithBothTags = $this->election1->getExplicitFilteredPairwiseByTags(['tag1','tag2'], 2);
+        $filteredWithBothTags = $this->election1->getExplicitFilteredPairwiseByTags(['tag1', 'tag2'], 2);
 
 
         // Test $filteredwithBothTags

--- a/Tests/src/Algo/Pairwise/FilteredPairwiseTest.php
+++ b/Tests/src/Algo/Pairwise/FilteredPairwiseTest.php
@@ -250,7 +250,7 @@ class FilteredPairwiseTest extends TestCase
 
         self::assertSame($explicitOriginalFromFilteredPairwise, $filteredPairwise->getExplicitPairwise());
         self::assertSame(['tag1'], $filteredPairwise->tags);
-        self::assertTrue($filteredPairwise->withTags);
+        self::assertSame(1, $filteredPairwise->withTags);
     }
 
     public function testModifyFilteredPairwise(): void
@@ -277,5 +277,70 @@ class FilteredPairwiseTest extends TestCase
         self::assertArrayHasKey('A', $filteredPairwise->getExplicitPairwise());
         self::assertArrayHasKey('B', $filteredPairwise->getExplicitPairwise());
         self::assertArrayHasKey('C', $filteredPairwise->getExplicitPairwise());
+    }
+
+    public function testFilteredPairwiseResults_2(): void
+    {
+        $this->election1->removeAllVotes();
+        $this->election1->allowsVoteWeight(true);
+
+        $this->election1->parseVotes('
+            A > B > C
+            tag1 || B > C > A
+            tag2 || A > B > C
+            tag1, tag2 || C > B > A *2
+        ');
+
+
+        $filteredWithBothTags = $this->election1->getExplicitFilteredPairwiseByTags(['tag1','tag2'], 2);
+
+
+        // Test $filteredwithBothTags
+        self::assertSame(
+            expected: [
+                'A' => [
+                    'win' => [
+                        'B' => 0,
+                        'C' => 0,
+                    ],
+                    'null' => [
+                        'B' => 0,
+                        'C' => 0,
+                    ],
+                    'lose' => [
+                        'B' => 2,
+                        'C' => 2,
+                    ],
+                ],
+                'B' => [
+                    'win' => [
+                        'A' => 2,
+                        'C' => 0,
+                    ],
+                    'null' => [
+                        'A' => 0,
+                        'C' => 0,
+                    ],
+                    'lose' => [
+                        'A' => 0,
+                        'C' => 2,
+                    ],
+                ],
+                'C' => [
+                    'win' => [
+                        'A' => 2,
+                        'B' => 2,
+                    ],
+                    'null' => [
+                        'A' => 0,
+                        'B' => 0,
+                    ],
+                    'lose' => [
+                        'A' => 0,
+                        'B' => 0,
+                    ],
+                ]],
+            actual: $filteredWithBothTags
+        );
     }
 }

--- a/src/Algo/Pairwise/FilteredPairwise.php
+++ b/src/Algo/Pairwise/FilteredPairwise.php
@@ -23,7 +23,7 @@ class FilteredPairwise extends Pairwise
     public function __construct(
         Election $link,
         array|string|null $tags = null,
-        public readonly int $withTags = 1
+        public readonly bool|int $withTags = true
     ) {
         $this->tags = VoteUtil::tagsConvert($tags);
 

--- a/src/Algo/Pairwise/FilteredPairwise.php
+++ b/src/Algo/Pairwise/FilteredPairwise.php
@@ -23,7 +23,7 @@ class FilteredPairwise extends Pairwise
     public function __construct(
         Election $link,
         array|string|null $tags = null,
-        public readonly bool $withTags = true
+        public readonly int $withTags = 1
     ) {
         $this->tags = VoteUtil::tagsConvert($tags);
 

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -118,22 +118,31 @@ class VotesManager extends ArrayManager
         }
     }
 
-    protected function getPartialVotesListGenerator(array $tags, bool $with): \Generator
+    protected function getPartialVotesListGenerator(array $tags, int|bool $with): \Generator
     {
+
         foreach ($this as $voteKey => $vote) {
+            $tagsfound = 0;
             $noOne = true;
             foreach ($tags as $oneTag) {
                 if (($oneTag === $voteKey) || \in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
-                    if ($with) {
+                    if ($with == 1) {
                         yield $voteKey => $vote;
                         break;
+                    } elseif ($with > 1) {
+                        $tagsfound++;
+                        if ($tagsfound >= $with) {
+                            yield $voteKey => $vote;
+                            break;
+                        }
                     } else {
                         $noOne = false;
                     }
                 }
             }
 
-            if (!$with && $noOne) {
+
+            if ($with == 0 && $noOne) {
                 yield $voteKey => $vote;
             }
         }
@@ -165,7 +174,7 @@ class VotesManager extends ArrayManager
         }
     }
 
-    public function getVotesValidUnderConstraintGenerator(?array $tags = null, bool $with = true): \Generator
+    public function getVotesValidUnderConstraintGenerator(?array $tags = null, int|bool $with = true): \Generator
     {
         $election = $this->getElection();
         $generator = ($tags === null) ? $this->getFullVotesListGenerator() : $this->getPartialVotesListGenerator($tags, $with);

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -127,7 +127,7 @@ class VotesManager extends ArrayManager
         foreach ($this as $voteKey => $vote) {
             $tagsfound = 0;
             foreach ($tags as $oneTag) {
-                if ($oneTag === $voteKey || \in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
+                if (\in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
                     if (++$tagsfound === $with) {
                         yield $voteKey => $vote;
                         break;

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -118,38 +118,31 @@ class VotesManager extends ArrayManager
         }
     }
 
-    protected function getPartialVotesListGenerator(array $tags, int|bool $with): \Generator
+    protected function getPartialVotesListGenerator(array $tags, bool|int $with): \Generator
     {
+        if (\is_bool($with)) {
+            $with = ($with) ? 1 : 0;
+        }
 
         foreach ($this as $voteKey => $vote) {
             $tagsfound = 0;
-            $noOne = true;
             foreach ($tags as $oneTag) {
-                if (($oneTag === $voteKey) || \in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
-                    if ($with == 1) {
+                if ($oneTag === $voteKey || \in_array(needle: $oneTag, haystack: $vote->getTags(), strict: true)) {
+                    if (++$tagsfound === $with) {
                         yield $voteKey => $vote;
                         break;
-                    } elseif ($with > 1) {
-                        $tagsfound++;
-                        if ($tagsfound >= $with) {
-                            yield $voteKey => $vote;
-                            break;
-                        }
-                    } else {
-                        $noOne = false;
                     }
                 }
             }
 
-
-            if ($with == 0 && $noOne) {
+            if ($with === 0 && $tagsfound === 0) {
                 yield $voteKey => $vote;
             }
         }
     }
 
     // Get the votes list
-    public function getVotesList(?array $tags = null, bool $with = true): array
+    public function getVotesList(?array $tags = null, bool|int $with = true): array
     {
         if ($tags === null) {
             return $this->getFullDataSet();
@@ -165,7 +158,7 @@ class VotesManager extends ArrayManager
     }
 
     // Get the votes list as a generator object
-    public function getVotesListGenerator(?array $tags = null, bool $with = true): \Generator
+    public function getVotesListGenerator(?array $tags = null, bool|int $with = true): \Generator
     {
         if ($tags === null) {
             return $this->getFullVotesListGenerator();
@@ -174,7 +167,7 @@ class VotesManager extends ArrayManager
         }
     }
 
-    public function getVotesValidUnderConstraintGenerator(?array $tags = null, int|bool $with = true): \Generator
+    public function getVotesValidUnderConstraintGenerator(?array $tags = null, bool|int $with = true): \Generator
     {
         $election = $this->getElection();
         $generator = ($tags === null) ? $this->getFullVotesListGenerator() : $this->getPartialVotesListGenerator($tags, $with);

--- a/src/ElectionProcess/ResultsProcess.php
+++ b/src/ElectionProcess/ResultsProcess.php
@@ -183,9 +183,9 @@ trait ResultsProcess
         #[FunctionParameter('Tags as string separated by commas or array')]
         array|string $tags,
         #[FunctionParameter('Votes with these tags or without')]
-        int|bool $with = true
+        bool|int $with = true
     ): FilteredPairwise {
-        return new FilteredPairwise($this, $tags, (int)$with);
+        return new FilteredPairwise($this, $tags, $with);
     }
 
     #[PublicAPI]

--- a/src/ElectionProcess/ResultsProcess.php
+++ b/src/ElectionProcess/ResultsProcess.php
@@ -183,9 +183,9 @@ trait ResultsProcess
         #[FunctionParameter('Tags as string separated by commas or array')]
         array|string $tags,
         #[FunctionParameter('Votes with these tags or without')]
-        bool $with = true
+        int|bool $with = true
     ): FilteredPairwise {
-        return new FilteredPairwise($this, $tags, $with);
+        return new FilteredPairwise($this, $tags, (int)$with);
     }
 
     #[PublicAPI]
@@ -204,8 +204,8 @@ trait ResultsProcess
     public function getExplicitFilteredPairwiseByTags(
         #[FunctionParameter('Tags as string separated by commas or array')]
         array|string $tags,
-        #[FunctionParameter('Votes with these tags or without')]
-        bool $with = true
+        #[FunctionParameter('Minimum number of specified tags that votes must include, or 0 for only votes without any specified tags')]
+        bool|int $with = 1
     ): array {
         return $this->getFilteredPairwiseByTags($tags, $with)->getExplicitPairwise();
     }


### PR DESCRIPTION
With my new commit, `getFilteredPairwise()` now accepts an int as the second argument to specify a minimum number of tags which must match the tags specified in the first argument, but if set to 0 it will only use votes without any of the specified tags.

I added a test for this. This test and all existing tests are now successful.