### PR TITLE
countVotes() now accepts a minimum number of tags.

### DIFF
--- a/Tests/src/ConstraintTest.php
+++ b/Tests/src/ConstraintTest.php
@@ -91,6 +91,8 @@ class ConstraintTest extends TestCase
 
             self::assertEquals(1, $this->election->sumValidVotesWeightWithConstraints());
             self::assertEquals(46, $this->election->sumVotesWeight());
+            self::assertEquals(45, $this->election->sumVotesWeight('tag1', false));
+            self::assertEquals(0, $this->election->sumValidVotesWeightWithConstraints('tag1', false));
             self::assertEquals(5, $this->election->countVotes());
             self::assertEquals(1, $this->election->countValidVoteWithConstraints());
             self::assertEquals(0, $this->election->countValidVoteWithConstraints('tag1', false));
@@ -105,6 +107,8 @@ class ConstraintTest extends TestCase
 
             self::assertEquals(43, $this->election->sumValidVotesWeightWithConstraints());
             self::assertEquals(46, $this->election->sumVotesWeight());
+            self::assertEquals(45, $this->election->sumVotesWeight('tag1', false));
+            self::assertEquals(42, $this->election->sumValidVotesWeightWithConstraints('tag1', false));
             self::assertEquals(5, $this->election->countVotes());
             self::assertEquals(2, $this->election->countValidVoteWithConstraints());
             self::assertEquals(1, $this->election->countValidVoteWithConstraints('tag1', false));
@@ -117,6 +121,8 @@ class ConstraintTest extends TestCase
 
             self::assertEquals(1, $this->election->sumValidVotesWeightWithConstraints());
             self::assertEquals(46, $this->election->sumVotesWeight());
+            self::assertEquals(45, $this->election->sumVotesWeight('tag1', false));
+            self::assertEquals(0, $this->election->sumValidVotesWeightWithConstraints('tag1', false));
             self::assertEquals(5, $this->election->countVotes());
             self::assertEquals(1, $this->election->countValidVoteWithConstraints());
             self::assertEquals(0, $this->election->countValidVoteWithConstraints('tag1', false));

--- a/Tests/src/ConstraintTest.php
+++ b/Tests/src/ConstraintTest.php
@@ -93,6 +93,7 @@ class ConstraintTest extends TestCase
             self::assertEquals(46, $this->election->sumVotesWeight());
             self::assertEquals(5, $this->election->countVotes());
             self::assertEquals(1, $this->election->countValidVoteWithConstraints());
+            self::assertEquals(0, $this->election->countValidVoteWithConstraints('tag1', false));
             self::assertEquals(4, $this->election->countInvalidVoteWithConstraints());
 
             self::assertEquals('A', $this->election->getWinner('FTPT'));
@@ -106,6 +107,7 @@ class ConstraintTest extends TestCase
             self::assertEquals(46, $this->election->sumVotesWeight());
             self::assertEquals(5, $this->election->countVotes());
             self::assertEquals(2, $this->election->countValidVoteWithConstraints());
+            self::assertEquals(1, $this->election->countValidVoteWithConstraints('tag1', false));
             self::assertEquals(3, $this->election->countInvalidVoteWithConstraints());
 
             self::assertTrue($this->election->setImplicitRanking(true));
@@ -117,6 +119,7 @@ class ConstraintTest extends TestCase
             self::assertEquals(46, $this->election->sumVotesWeight());
             self::assertEquals(5, $this->election->countVotes());
             self::assertEquals(1, $this->election->countValidVoteWithConstraints());
+            self::assertEquals(0, $this->election->countValidVoteWithConstraints('tag1', false));
             self::assertEquals(4, $this->election->countInvalidVoteWithConstraints());
             self::assertCount(1, iterator_to_array($this->election->getVotesValidUnderConstraintGenerator(['tag1'], true)));
             self::assertCount(0, iterator_to_array($this->election->getVotesValidUnderConstraintGenerator(['tag1'], false)));

--- a/Tests/src/DataManager/VotesManagerTest.php
+++ b/Tests/src/DataManager/VotesManagerTest.php
@@ -119,4 +119,21 @@ class VotesManagerTest extends TestCase
         self::assertEquals($this->election->getVotesList('tag42'), $votesListGenerator);
         self::assertCount(42, $votesListGenerator);
     }
+
+    public function testCountVotes(): void
+    {
+        self::assertEmpty($this->votes_manager->getVotesList());
+
+        $this->election->parseVotes('
+            A>B>C * 10;
+            tag42 || C>B>A * 42
+            tag44 || B>C>A * 26
+            tag42, tag44 || A>C>B * 18
+        ');
+
+        self::assertEquals(60, $this->votes_manager->countVotes(['tag42'], 1));
+        self::assertEquals(44, $this->votes_manager->countVotes(['tag44'], 1));
+        self::assertEquals(18, $this->votes_manager->countVotes(['tag42', 'tag44'], 2));
+        self::assertEquals(52, $this->votes_manager->countVotes(['tag44'], 0));
+    }
 }

--- a/Tests/src/DataManager/VotesManagerTest.php
+++ b/Tests/src/DataManager/VotesManagerTest.php
@@ -133,7 +133,9 @@ class VotesManagerTest extends TestCase
 
         self::assertEquals(60, $this->votes_manager->countVotes(['tag42'], 1));
         self::assertEquals(44, $this->votes_manager->countVotes(['tag44'], 1));
+        self::assertEquals(44, $this->votes_manager->countVotes(['tag44'], true));
         self::assertEquals(18, $this->votes_manager->countVotes(['tag42', 'tag44'], 2));
         self::assertEquals(52, $this->votes_manager->countVotes(['tag44'], 0));
+        self::assertEquals(52, $this->votes_manager->countVotes(['tag44'], false));
     }
 }

--- a/Tests/src/ElectionTest.php
+++ b/Tests/src/ElectionTest.php
@@ -500,8 +500,8 @@ class ElectionTest extends TestCase
         $election->addCandidate('D');
 
         $election->parseVotes('
-            A > C > D * 6
-            B > A > D * 1
+            tag1 || A > C > D * 6
+            tag2 || B > A > D * 1
             C > B > D * 3
             D > B > A * 3
         ');
@@ -514,6 +514,28 @@ class ElectionTest extends TestCase
             $election->sumVotesWeight()
         );
 
+        self::assertSame(
+            $election->sumVotesWeight(),
+            $election->sumValidVotesWeightWithConstraints()
+        );
+
+        // Some test about votes weight tags filters
+        self::assertSame(
+            7,
+            $election->sumVotesWeight('tag1,tag2')
+        );
+
+        self::assertSame(
+            13,
+            $election->sumVotesWeight('tag2', false)
+        );
+
+        self::assertSame(
+            0,
+            $election->sumVotesWeight('tag1,tag2', 2)
+        );
+
+        // Continue
         self::assertSame(
             'D > C > B ^2',
             (string) $voteWithWeight

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -225,28 +225,15 @@ class VotesManager extends ArrayManager
         return $simpleList;
     }
 
-    public function countVotes(?array $tag, bool|int $with): int
+    public function countVotes(?array $tags, bool|int $with): int
     {
-        if ($tag === null) {
+        if ($tags === null) {
             return \count($this);
         } else {
             $count = 0;
 
-            foreach ($this as $key => $value) {
-                $tagsfound = 0;
-                foreach ($tag as $oneTag) {
-                    if (($oneTag === $key) || \in_array(needle: $oneTag, haystack: $value->getTags(), strict: true)) {
-                        $tagsfound++;
-                        if ($with > 0 AND $tagsfound >= $with) {
-                            $count++;
-                            break;
-                        }
-                    }
-                }
-
-                if ($with == 0 && $tagsfound == 0) {
-                    $count++;
-                }
+            foreach ($this->getPartialVotesListGenerator($tags, $with) as $vote) {
+                $count++;
             }
 
             return $count;

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -225,7 +225,7 @@ class VotesManager extends ArrayManager
         return $simpleList;
     }
 
-    public function countVotes(?array $tag, bool $with): int
+    public function countVotes(?array $tag, bool|int $with): int
     {
         if ($tag === null) {
             return \count($this);
@@ -233,19 +233,18 @@ class VotesManager extends ArrayManager
             $count = 0;
 
             foreach ($this as $key => $value) {
-                $noOne = true;
+                $tagsfound = 0;
                 foreach ($tag as $oneTag) {
                     if (($oneTag === $key) || \in_array(needle: $oneTag, haystack: $value->getTags(), strict: true)) {
-                        if ($with) {
+                        $tagsfound++;
+                        if ($with > 0 AND $tagsfound >= $with) {
                             $count++;
                             break;
-                        } else {
-                            $noOne = false;
                         }
                     }
                 }
 
-                if (!$with && $noOne) {
+                if ($with == 0 && $tagsfound == 0) {
                     $count++;
                 }
             }

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -235,7 +235,7 @@ class VotesManager extends ArrayManager
         }
     }
 
-    public function countValidVotesWithConstraint(?array $tags, bool|int $with): int
+    public function countValidVotesWithConstraints(?array $tags, bool|int $with): int
     {
         $election = $this->getElection();
         $count = 0;
@@ -263,13 +263,24 @@ class VotesManager extends ArrayManager
         return $count;
     }
 
-    public function sumVotesWeight(bool $constraint = false): int
+    public function sumVotesWeight(?array $tags, bool|int $with): int
+    {
+        return $this->processSumVotesWeight(tags: $tags, with: $with, constraints: false);
+    }
+
+    public function sumVotesWeightWithConstraints(?array $tags, bool|int $with): int
+    {
+        return $this->processSumVotesWeight(tags: $tags, with: $with, constraints: true);
+    }
+
+    protected function processSumVotesWeight(?array $tags, bool|int $with, bool $constraints)
     {
         $election = $this->getElection();
         $sum = 0;
 
-        foreach ($this as $oneVote) {
-            if (!$constraint || $election->testIfVoteIsValidUnderElectionConstraints($oneVote)) {
+        foreach ($this->getVotesListGenerator($tags, $with) as $oneVote) {
+            if (!$constraints || $election->testIfVoteIsValidUnderElectionConstraints($oneVote)) # They are no constraints check OR the vote is valid.
+            {
                 $sum += $election->isVoteWeightAllowed() ? $oneVote->getWeight() : 1;
             }
         }

--- a/src/DataManager/VotesManager.php
+++ b/src/DataManager/VotesManager.php
@@ -160,19 +160,14 @@ class VotesManager extends ArrayManager
     // Get the votes list as a generator object
     public function getVotesListGenerator(?array $tags = null, bool|int $with = true): \Generator
     {
-        if ($tags === null) {
-            return $this->getFullVotesListGenerator();
-        } else {
-            return $this->getPartialVotesListGenerator($tags, $with);
-        }
+        return ($tags === null) ? $this->getFullVotesListGenerator() : $this->getPartialVotesListGenerator($tags, $with);
     }
 
     public function getVotesValidUnderConstraintGenerator(?array $tags = null, bool|int $with = true): \Generator
     {
         $election = $this->getElection();
-        $generator = ($tags === null) ? $this->getFullVotesListGenerator() : $this->getPartialVotesListGenerator($tags, $with);
 
-        foreach ($generator as $voteKey => $oneVote) {
+        foreach ($this->getVotesListGenerator($tags, $with) as $voteKey => $oneVote) {
             if (!$election->testIfVoteIsValidUnderElectionConstraints($oneVote)) {
                 continue;
             }
@@ -238,6 +233,20 @@ class VotesManager extends ArrayManager
 
             return $count;
         }
+    }
+
+    public function countValidVotesWithConstraint(?array $tags, bool|int $with): int
+    {
+        $election = $this->getElection();
+        $count = 0;
+
+        foreach ($this->getVotesListGenerator($tags, $with) as $oneVote) {
+            if ($election->testIfVoteIsValidUnderElectionConstraints($oneVote)) {
+                $count++;
+            }
+        }
+
+        return $count;
     }
 
     public function countInvalidVoteWithConstraints(): int

--- a/src/ElectionProcess/VotesProcess.php
+++ b/src/ElectionProcess/VotesProcess.php
@@ -39,7 +39,7 @@ trait VotesProcess
         #[FunctionParameter('Tag into string separated by commas, or an Array')]
         array|null|string $tags = null,
         #[FunctionParameter('Count Votes with this tag ou without this tag-')]
-        bool $with = true
+        bool|int $with = true
     ): int {
         return $this->Votes->countVotes(VoteUtil::tagsConvert($tags), $with);
     }

--- a/src/ElectionProcess/VotesProcess.php
+++ b/src/ElectionProcess/VotesProcess.php
@@ -57,9 +57,13 @@ trait VotesProcess
     #[Description("Count the number of actual registered and valid vote for this election. This method don't ignore votes constraints, only valid vote will be counted.")]
     #[FunctionReturn('Number of valid and registered vote into this election.')]
     #[Related('Election::countInvalidVoteWithConstraints', 'Election::countVotes', 'Election::sumValidVotesWeightWithConstraints')]
-    public function countValidVoteWithConstraints(): int
-    {
-        return $this->countVotes() - $this->countInvalidVoteWithConstraints();
+    public function countValidVoteWithConstraints(
+        #[FunctionParameter('Tag into string separated by commas, or an Array')]
+        array|null|string $tags = null,
+        #[FunctionParameter('Count Votes with this tag ou without this tag-')]
+        bool|int $with = true
+    ): int {
+        return $this->Votes->countValidVotesWithConstraint(VoteUtil::tagsConvert($tags), $with);
     }
 
     // Sum votes weight

--- a/src/ElectionProcess/VotesProcess.php
+++ b/src/ElectionProcess/VotesProcess.php
@@ -63,7 +63,7 @@ trait VotesProcess
         #[FunctionParameter('Count Votes with this tag ou without this tag-')]
         bool|int $with = true
     ): int {
-        return $this->Votes->countValidVotesWithConstraint(VoteUtil::tagsConvert($tags), $with);
+        return $this->Votes->countValidVotesWithConstraints(VoteUtil::tagsConvert($tags), $with);
     }
 
     // Sum votes weight
@@ -71,18 +71,28 @@ trait VotesProcess
     #[Description('Sum total votes weight in this election. If vote weight functionality is disable (default setting), it will return the number of registered votes. This method ignore votes constraints.')]
     #[FunctionReturn('(Int) Total vote weight')]
     #[Related('Election::sumValidVotesWeightWithConstraints')]
-    public function sumVotesWeight(): int
+    public function sumVotesWeight(
+        #[FunctionParameter('Tag into string separated by commas, or an Array')]
+        array|null|string $tags = null,
+        #[FunctionParameter('Count Votes with this tag ou without this tag-')]
+        bool|int $with = true
+    ): int
     {
-        return $this->Votes->sumVotesWeight(false);
+        return $this->Votes->sumVotesWeight(VoteUtil::tagsConvert($tags), $with);
     }
 
     #[PublicAPI]
     #[Description("Sum total votes weight in this election. If vote weight functionality is disable (default setting), it will return the number of registered votes. This method don't ignore votes constraints, only valid vote will be counted.")]
     #[FunctionReturn('(Int) Total vote weight')]
     #[Related('Election::countValidVoteWithConstraints', 'Election::countInvalidVoteWithConstraints')]
-    public function sumValidVotesWeightWithConstraints(): int
+    public function sumValidVotesWeightWithConstraints(
+        #[FunctionParameter('Tag into string separated by commas, or an Array')]
+        array|null|string $tags = null,
+        #[FunctionParameter('Count Votes with this tag ou without this tag-')]
+        bool|int $with = true
+    ): int
     {
-        return $this->Votes->sumVotesWeight(true);
+        return $this->Votes->sumVotesWeightWithConstraints(VoteUtil::tagsConvert($tags), $with);
     }
 
     // Get the votes registered list


### PR DESCRIPTION
These additions are very much like the recent ones. I just made it so that the second parameter in the countVotes() function can be an int specifying the minimum number of tags that must match, or 0 to require none of them to match.

I also added a test. There was previously no test for this function.